### PR TITLE
General cleanup and corrections

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 # file names.
 #
 # @see https://voxpupuli.org/puppet-autofs Home
-# @see https://www.github.com/voxpupuli/autofs-puppet Github
+# @see https://www.github.com/voxpupuli/puppet-autofs Github
 # @see https://forge.puppet.com/puppet/autofs Puppet Forge
 #
 # @author Vox Pupuli <voxpupuli@groups.io>

--- a/metadata.json
+++ b/metadata.json
@@ -90,18 +90,14 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 2015.2.0 <= 2016.5.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.1 < 5.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Simply brought the puppet and stdlib version numbers in the metadata.json inline with the Vox Pupuli [Puppet 4](https://voxpupuli.org/blog/2017/01/11/migrating-to-puppet4/) standards.

Also made a correction to the `@see` strings tag in the init.pp that pointed to the wrong Github url