### PR TITLE
BREAKING Make package and service private

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,3 +1,4 @@
+# @api private
 # Class: autofs::package
 #
 # The autofs::package class installs the autofs package.
@@ -18,7 +19,10 @@
 # If the code doesn't find a matching supported OS, then the Puppet run will fail
 # with a "OS not supported" message.
 #
+# This is a private class and cannot be called outside of the autofs module.
+#
 class autofs::package {
+  assert_private('Package class is private, please use main class parameters')
   Package {
     ensure => $autofs::package_ensure,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,12 @@
+# @api private
 # Class: autofs::service
 #
 # The autofs::service class configures the autofs service.
 # This class can be used to disable or limit the autofs service
 # if necessary. Such as allowing the service to run, but not at
 # startup.
+#
+# This class is private and cannot be called outside of the autofs module
 #
 # @see https://voxpupuli.org/puppet-autofs Home
 # @see autofs
@@ -14,6 +17,7 @@
 # @author David Hollinger III <david.hollinger@moduletux.com>
 #
 class autofs::service {
+  assert_private('Service class is private, please use main class parameters.')
   service { 'autofs':
     ensure     => $autofs::service_ensure,
     enable     => $autofs::service_enable,


### PR DESCRIPTION
Makes the package and service classes private to ensure that the service and package resources function as expected.

Closes #24 