### PR TITLE
With new Stdlib type Asolutepath empty string is not valid.

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -40,18 +40,18 @@
 define autofs::mount (
   Stdlib::Absolutepath $mount,
   Integer              $order,
-  Stdlib::Absolutepath $mapfile = '',
-  Optional[String] $options     = '',
-  Stdlib::Absolutepath $master  = '/etc/auto.master',
-  Stdlib::Absolutepath $map_dir = '/etc/auto.master.d',
-  Boolean $use_dir              = false,
-  Boolean $direct               = true,
-  Boolean $execute              = false,
-  Array $mapcontents            = [],
-  Boolean $replace              = true
+  Optional[Stdlib::Absolutepath] $mapfile = undef,
+  Optional[String] $options               = '',
+  Stdlib::Absolutepath $master            = '/etc/auto.master',
+  Stdlib::Absolutepath $map_dir           = '/etc/auto.master.d',
+  Boolean $use_dir                        = false,
+  Boolean $direct                         = true,
+  Boolean $execute                        = false,
+  Array $mapcontents                      = [],
+  Boolean $replace                        = true
 ) {
 
-  if $mapfile != '' {
+  if $mapfile {
     $contents = "${mount} ${mapfile} ${options}\n"
   } else {
     $contents = "${mount} ${options}\n"
@@ -111,7 +111,7 @@ define autofs::mount (
     }
   }
 
-  if $mapfile != '' {
+  if $mapfile {
     file { $mapfile:
       ensure  => present,
       owner   => 'root',

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -127,4 +127,22 @@ describe 'autofs::mount', type: :define do
       is_expected.to contain_file('/etc/auto.home').with('mode' => '0755')
     end
   end
+
+  context 'without mapfile' do
+    let(:params) do
+      {
+        mount: '/net',
+        options: '-host',
+        use_dir: false,
+        order: 1
+      }
+    end
+
+    it do
+      is_expected.not_to contain_file('/etc/auto.-host')
+      is_expected.to contain_concat__fragment('autofs::fragment preamble /net ').with_content(
+        %r{/net -host\n}
+      )
+    end
+  end
 end


### PR DESCRIPTION
Set the default value to undef for map file, which will allow for
the ability to use already defined system resources like

/net -hosts

Suggestion for #18 
