### PR TITLE
automount different on Solaris

### DIFF
--- a/lib/facter/autofs.rb
+++ b/lib/facter/autofs.rb
@@ -1,4 +1,5 @@
 Facter.add(:autofs_version) do
+  confine :kernel => 'Linux'
   setcode do
     if Facter::Util::Resolution.which('automount')
       autofs_version_command = 'automount -V 2>&1'


### PR DESCRIPTION
automount has no version flag I could identify on a Solaris 10 box.  Confining to prevent puppet runs for now.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
