### PR TITLE
Bump minimum required stdlib version to 4.13.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -97,7 +97,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
This module uses the type `Stdlib::Absolutepath`, which was introduced in stdlib 4.13
https://github.com/puppetlabs/puppetlabs-stdlib/blob/5eebb740589a9f128b8d6a5cb7e40a347562f5fb/CHANGELOG.md#features-3

Fixes #46