### PR TITLE
Fix rubocop errors

### DIFF
--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -3,9 +3,10 @@ require 'hiera'
 
 describe 'autofs', type: :class do
   let(:hiera_config) { 'spec/fixtures/hiera/hiera.yaml' }
+
   hiera = Hiera.new(config: 'spec/fixtures/hiera/hiera.yaml')
 
-  on_supported_os.select { |_, f| f[:os]['family'] != 'Solaris' }.each do |os, facts|
+  on_supported_os.reject { |_, f| f[:os]['family'] == 'Solaris' }.each do |os, facts|
     context "on #{os}" do
       let :facts do
         facts
@@ -15,6 +16,7 @@ describe 'autofs', type: :class do
         let(:facts) do
           facts.merge(concat_basedir: '/etc')
         end
+
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('autofs') }
         it { is_expected.to contain_class('autofs::package') }
@@ -37,6 +39,7 @@ describe 'autofs', type: :class do
           package_ensure: 'absent'
         }
       end
+
       it { is_expected.to contain_package('autofs').with_ensure('absent') }
     end
   end
@@ -44,11 +47,12 @@ describe 'autofs', type: :class do
   context 'it should create auto.home' do
     mounts = hiera.lookup('homedir', nil, nil)
     let(:params) { { mounts: mounts } }
+
     it 'is expected to have auto.home hiera values' do
       expect(mounts).to include(
         'mount' => '/home',
         'mapfile' => '/etc/auto.home',
-        'mapcontents' => %w(test foo bar),
+        'mapcontents' => %w[test foo bar],
         'options' => '--timeout=120',
         'order' => 1
       )
@@ -58,11 +62,12 @@ describe 'autofs', type: :class do
   context 'it should create home direct mount' do
     mounts = hiera.lookup('direct', nil, nil)
     let(:params) { { mounts: mounts } }
+
     it 'is expected to have direct mount hiera values' do
       expect(mounts).to include(
         'mount' => '/-',
         'mapfile' => '/etc/auto.home',
-        'mapcontents' => %w(/home\ /test /home\ /foo /home\ /bar),
+        'mapcontents' => %w[/home\ /test /home\ /foo /home\ /bar],
         'options' => '--timeout=120',
         'order' => 1
       )
@@ -72,11 +77,12 @@ describe 'autofs', type: :class do
   context 'hiera_confdir_test' do
     mounts = hiera.lookup('confdir', nil, nil)
     let(:params) { { mounts: mounts } }
+
     it 'is expected to have auto.master.d hiera values' do
       expect(mounts).to include(
         'mount' => '/home',
         'mapfile' => '/etc/auto.home',
-        'mapcontents' => %w(*\ -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl\ server.example.com:/path/to/home/shares),
+        'mapcontents' => %w[*\ -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl\ server.example.com:/path/to/home/shares],
         'options' => '--timeout=120',
         'order' => 1,
         'use_dir' => true
@@ -87,6 +93,7 @@ describe 'autofs', type: :class do
   context 'Parameter is not a hash' do
     mounts = 'string'
     let(:params) { { mounts: mounts } }
+
     it 'is expected to fail' do
       is_expected.to compile.and_raise_error(%r{parameter 'mounts' expects a value of type Undef or Hash})
     end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -12,7 +12,7 @@ describe 'autofs::mount', type: :define do
     {
       mount: '/home',
       mapfile: '/etc/auto.home',
-      mapcontents: %w(test foo bar),
+      mapcontents: %w[test foo bar],
       options: '--timeout=120',
       order: 0o1,
       master: '/etc/auto.master'
@@ -40,7 +40,7 @@ describe 'autofs::mount', type: :define do
       {
         mount: '/home',
         mapfile: '/etc/auto.home',
-        mapcontents: %w(test foo bar),
+        mapcontents: %w[test foo bar],
         options: '--timeout=120',
         order: 0o1,
         direct: false
@@ -75,7 +75,7 @@ describe 'autofs::mount', type: :define do
         name: 'home',
         mount: '/home',
         mapfile: '/etc/auto.home',
-        mapcontents: %w(test foo bar),
+        mapcontents: %w[test foo bar],
         options: '--timeout=120',
         order: 0o1,
         map_dir: '/etc/auto.master.d',
@@ -116,7 +116,7 @@ describe 'autofs::mount', type: :define do
       {
         mount: '/home',
         mapfile: '/etc/auto.home',
-        mapcontents: %w(test foo bar),
+        mapcontents: %w[test foo bar],
         options: '--timeout=120',
         order: 0o1,
         execute: true


### PR DESCRIPTION
Fix rubocop errors in the unit tests.

The acceptance Rubocop errors are fixed by #51 