### PR TITLE
Introduce new type autofs::map

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,38 @@ autofs::mounts:
     use_dir: true
 ```
 
+#### Map Entries
+In addition to adding map entries via the `mapcontents` parameter to `autofs::mount the `autofs::map` type can also be used.
+
+##### Usage
+
+Define:
+```puppet
+autofs::map{'data':
+  map => '/etc/auto.data',
+  mapcontent => 'data -user,rw,soft server.example.com:/path/to/data,
+}
+```
+
+Hiera:
+```yaml
+autofs::maps:
+  data:
+    map: '/etc/auto.data'
+    mapcontent: 'data -user,rw server.example.com:/path/to/data'
+```
+
+It is assumed that the map file itself has already been defined with
+and `autofs::mount` first.
+
+```puppet
+autofs::mount{'auto.data':
+  mapfile => '/etc/auto.data',
+  mount   => '/big',
+}
+```
+
+
 ## Reference
 
 ### Classes
@@ -227,8 +259,9 @@ Default: `true`
 #### Public Defines
 
 * autofs::mount: Builds the autofs configuration.
+* autofs::map: Builds map entires for autofs configuration.
 
-### Parameters
+### Parameters for autofs::mount
 
 #### `mount_name`
 
@@ -331,6 +364,23 @@ Data type: Boolean
 Whether or not to replace the mapfile if it already exists.
 
 Default: `true`
+
+### Parameters for autofs::map
+
+#### `mapfile`
+
+Data type: Stdlib::Absolutepath
+
+mapfile file to add entry to. e.g '/etc/auto.data'.
+
+#### `mapcontent`
+
+Data type: String
+
+This Mapping describes a folder that will be mounted, the
+mount options, and the path to the remote or local share to be mounted. Used in
+mapfile generation. e.g. 'data -rw nfs.example.org:/data/big
+
 
 Limitations
 ------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@
 #
 class autofs (
   Optional[Hash] $mounts                       = undef,
+  Optional[Hash] $maps                         = undef,
   String $package_ensure                       = 'installed',
   Enum[ 'stopped', 'running' ] $service_ensure = 'running',
   Boolean $service_enable                      = true,
@@ -79,5 +80,9 @@ class autofs (
   if $mounts {
     $data = hiera_hash('autofs::mounts', $mounts)
     create_resources('autofs::mount', $data)
+  }
+  if $maps {
+    $_datamaps = hiera_hash('autofs::maps', $maps)
+    create_resources('autofs::map',$_datamaps)
   }
 }

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -1,0 +1,38 @@
+# Define: autofs::map
+#
+# Defined type to generate autofs map entry
+# configuration files.
+#
+# @see https://voxpupuli.org/puppet-autofs Home
+# @see https://voxpupuli.org/puppet-autofs/puppet_classes/autofs.html puppet_classes::autofs
+# @see https://www.github.com/voxpupuli/puppet-autofs Github
+# @see https://forge.puppet.com/puppet/autofs Puppet Forge
+#
+# @author Vox Pupuli <voxpupuli@groups.io>
+# @author David Hollinger III <david.hollinger@moduletux.com>
+#
+# @example Using the autofs::map defined type to setup automount for nfs data directory.
+#   autofs::map { 'data':
+#     mapcontent => 'mydata -user,rw,soft,intr,rsize=32768,wsize=32768  nfs.example.org:/path/to/some/data',
+#     mapfile => '/etc/auto.data',
+#     order   => '01',
+#   }
+#
+# @param mapcontent The mount point options and parameters, 
+#   Example: '* -user,rw,soft nfs.example.org:/path/to'
+# @param mapfile Name of the "auto." configuration file that will be generated.
+# @param order Order in which entries will appear in the autofs map file.
+
+define autofs::map (
+  String               $mapcontent,
+  Stdlib::Absolutepath $mapfile,
+  Integer              $order = 1,
+) {
+
+  concat::fragment{"${mapfile}_${mapcontent}":
+    target  => $mapfile,
+    content => "${mapcontent}\n",
+    order   => $order,
+  }
+
+}

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -112,16 +112,19 @@ define autofs::mount (
   }
 
   if $mapfile {
-    file { $mapfile:
+    concat { $mapfile:
       ensure  => present,
       owner   => 'root',
       group   => 'root',
       mode    => $mapperms,
       replace => $replace,
-      content => template($maptempl),
       require => Package[ 'autofs' ],
       notify  => Service[ 'autofs' ],
     }
+    concat::fragment{"${mapfile}_entries":
+      target  => $mapfile,
+      content => template($maptempl),
+      order   => 1,
+    }
   }
-
 }

--- a/spec/acceptance/autofs_map_spec.rb
+++ b/spec/acceptance/autofs_map_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper_acceptance'
+
+describe 'autofs::map  tests' do
+  context 'basic map test' do
+    it 'applies' do
+      pp = <<-EOS
+        class { 'autofs': }
+        autofs::mount { 'data':
+          mount       => '/data',
+          mapfile     => '/etc/auto.data',
+          mapcontents => ['dataB -o rw /mnt/dataB'],
+          options     => '--timeout=120',
+          order       => 01
+        }
+	autofs::map {'dataC':
+	  mapfile => '/etc/auto.data',
+	  mapcontent => 'dataC -o rw /mnt/dataC',
+         }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.master') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        shell('cat /etc/auto.master') do |s|
+          expect(s.stdout).to match(%r{/data /etc/auto.data --timeout=120})
+        end
+      end
+    end
+
+    describe file('/etc/auto.data') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        shell('cat /etc/auto.data') do |s|
+          expect(s.stdout).to match(%r{(dataA -o rw /mnt/dataA|dataC -o rw /mnt/dataC)})
+        end
+      end
+    end
+
+    describe package('autofs') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('autofs') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+end

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -46,6 +46,7 @@ describe 'autofs', type: :class do
 
   context 'it should create auto.home' do
     mounts = hiera.lookup('homedir', nil, nil)
+    maps = hiera.lookup('homedir_maps', nil, nil)
     let(:params) { { mounts: mounts } }
 
     it 'is expected to have auto.home hiera values' do
@@ -55,6 +56,12 @@ describe 'autofs', type: :class do
         'mapcontents' => %w[test foo bar],
         'options' => '--timeout=120',
         'order' => 1
+      )
+    end
+    it 'is expected to have auto.home hiera values' do
+      expect(maps).to include(
+        'mapfile' => '/etc/auto.home',
+        'mapcontent' => '/home /another'
       )
     end
   end

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+describe 'autofs::map', type: :define do
+  let(:title) { 'data' }
+
+  let(:facts) do
+    {
+      concat_basedir: '/etc'
+    }
+  end
+
+  let(:params) do
+    {
+      mapfile: '/etc/auto.data',
+      mapcontent: 'test foo bar',
+      order: 0o1
+    }
+  end
+
+  context 'with default parameters' do
+    it do
+      is_expected.to contain_concat__fragment('/etc/auto.data_test foo bar').with(
+        'target' => '/etc/auto.data',
+        'content' => "test foo bar\n"
+      )
+    end
+  end
+end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -26,11 +26,14 @@ describe 'autofs::mount', type: :define do
     end
 
     it do
-      is_expected.to contain_file('/etc/auto.home').with(
+      is_expected.to contain_concat('/etc/auto.home').with(
         'ensure' => 'present',
         'owner'  => 'root',
         'group'  => 'root',
         'mode'   => '0644'
+      )
+      is_expected.to contain_concat__fragment('/etc/auto.home_entries').with(
+        'target' => '/etc/auto.home'
       )
     end
   end
@@ -102,7 +105,7 @@ describe 'autofs::mount', type: :define do
         'mode'   => '0644'
       )
 
-      is_expected.to contain_file('/etc/auto.home').with(
+      is_expected.to contain_concat('/etc/auto.home').with(
         'ensure' => 'present',
         'owner'  => 'root',
         'group'  => 'root',
@@ -124,7 +127,7 @@ describe 'autofs::mount', type: :define do
     end
 
     it do
-      is_expected.to contain_file('/etc/auto.home').with('mode' => '0755')
+      is_expected.to contain_concat('/etc/auto.home').with('mode' => '0755')
     end
   end
 
@@ -139,7 +142,7 @@ describe 'autofs::mount', type: :define do
     end
 
     it do
-      is_expected.not_to contain_file('/etc/auto.-host')
+      is_expected.not_to contain_concat('/etc/auto.-host')
       is_expected.to contain_concat__fragment('autofs::fragment preamble /net ').with_content(
         %r{/net -host\n}
       )

--- a/spec/fixtures/hiera/test.yaml
+++ b/spec/fixtures/hiera/test.yaml
@@ -8,6 +8,9 @@ homedir:
       - 'bar'
     options: '--timeout=120'
     order: 01
+homedir_maps:
+    mapfile: '/etc/auto.home'
+    mapcontent: '/home /another'
 direct:
     mount: '/-'
     mapfile: '/etc/auto.home'


### PR DESCRIPTION
autofs::map allows a map entry to be added to
a pre configured map file. e.g.

```puppet
autofs::mount{'/data':
  mapfile => '/etc/auto.data',
  mount   => '/data',
  mapcontents => [
    'C -rw nfs.example.org:/path/to/C',
    'C -rw nfs.example.org:/path/to/C',
  ]
}

autofs::map{'A':
  mapfile  => '/etc/auto.data',
  mapcontent => 'A -rw  nfs.example.org:/path/to/A',
}
```

In this case the `auto.data` file is now managed as a concat file.

The motivation here is to make the configuration more modular.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
