### PR TITLE
New boolean mapfile_manage to manage mapfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ This Mapping describes the name and path of the autofs map file.
 This mapping is used in the auto.master generation, as well as generating the map
 file from the auto.map.erb template. This parameter is no longer required.
 
+#### `mapfile_manage`
+
+Data type: Boolean
+
+If true the the mapfile file will be created and maintained. Defaults
+to true. Set this to false when the map file is maintained some other way,
+e.g auto.smb from the autofs package.
+
 #### `mapcontents`
 
 Data type: Array

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -35,6 +35,8 @@
 #   backwards compatible.
 # @param execute If true, it will make the $mapfile an executable script,
 #   otherwise the file is a standard "auto." configuration file.
+# @param mapfile_manage Boolean will manaage the map file specifed in mapfile
+#   paramter. Defaults to true to maintin backwards compatability.
 # @param replace Set to false if you only want to place the file if it is missing.
 #
 define autofs::mount (
@@ -47,6 +49,7 @@ define autofs::mount (
   Boolean $use_dir                        = false,
   Boolean $direct                         = true,
   Boolean $execute                        = false,
+  Boolean $mapfile_manage                 = true,
   Array $mapcontents                      = [],
   Boolean $replace                        = true
 ) {
@@ -111,7 +114,7 @@ define autofs::mount (
     }
   }
 
-  if $mapfile {
+  if $mapfile and $mapfile_manage {
     autofs::map { $title:
       mapfile    => $mapfile,
       mapcontent => $mapcontents,

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -39,6 +39,23 @@ describe 'autofs::mount', type: :define do
     end
   end
 
+  context 'with unmanged mapfile' do
+    let(:params) do
+      {
+        mount: '/smb',
+        mapfile: '/etc/auto.smb',
+        mapfile_manage: false,
+        options: '--timeout=120',
+        order: 2,
+        direct: false
+      }
+    end
+
+    it do
+      is_expected.not_to contain_file('/etc/auto.smb')
+    end
+  end
+
   context 'with indirect map' do
     let(:params) do
       {


### PR DESCRIPTION
It is desirable some times to create and auto.master
entry and not maintain the map file. An example would be

```puppet
autofs::mount{'smb':
  mount          => '/smb',
  mapfile        => '/etc/auto.smb',
  manage_mapfile => false,
}
```

In this case the auto.smb is a script provied by the autofs package
and should not be under puppet's control.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
