### PR TITLE
Update map and mount defined types to address #59

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -42,7 +42,7 @@ define autofs::map (
     notify  => Service['autofs'],
   }
 
-  concat::fragment{"${mapfile}_${mapcontent}":
+  concat::fragment{"${mapfile}_entries":
     target  => $mapfile,
     content => template($template),
     order   => $order,

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -38,8 +38,8 @@ define autofs::map (
     group   => 'root',
     mode    => $mapmode,
     replace => $replace,
-    require => Package[ 'autofs' ],
-    notify  => Service[ 'autofs' ],
+    require => Package['autofs'],
+    notify  => Service['autofs'],
   }
 
   concat::fragment{"${mapfile}_${mapcontent}":

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -24,14 +24,27 @@
 # @param order Order in which entries will appear in the autofs map file.
 
 define autofs::map (
-  String               $mapcontent,
+  Array $mapcontent,
   Stdlib::Absolutepath $mapfile,
-  Integer              $order = 1,
+  Enum['autofs/auto.map.erb', 'autofs/auto.map.exec.erb'] $template = 'autofs/auto.map.erb',
+  String $mapmode                                                   = '0644',
+  Boolean $replace                                                  = true,
+  Integer $order                                                    = 1,
 ) {
+
+  concat { $mapfile:
+    ensure  => present,
+    owner   => 'root',
+    group   => 'root',
+    mode    => $mapmode,
+    replace => $replace,
+    require => Package[ 'autofs' ],
+    notify  => Service[ 'autofs' ],
+  }
 
   concat::fragment{"${mapfile}_${mapcontent}":
     target  => $mapfile,
-    content => "${mapcontent}\n",
+    content => template($template),
     order   => $order,
   }
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -72,7 +72,7 @@ define autofs::mount (
       group          => 'root',
       mode           => '0644',
       ensure_newline => true,
-      notify         => Service[ 'autofs' ],
+      notify         => Service['autofs'],
     }
   }
 
@@ -96,7 +96,7 @@ define autofs::mount (
         target  => $master,
         content => "+dir:${map_dir}",
         order   => $order,
-        require => File[ $map_dir ],
+        require => File[$map_dir],
       }
     }
 
@@ -106,8 +106,8 @@ define autofs::mount (
       group   => 'root',
       mode    => $mapperms,
       content => $contents,
-      require => File[ $map_dir ],
-      notify  => Service[ 'autofs' ],
+      require => File[$map_dir],
+      notify  => Service['autofs'],
     }
   }
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -112,19 +112,12 @@ define autofs::mount (
   }
 
   if $mapfile {
-    concat { $mapfile:
-      ensure  => present,
-      owner   => 'root',
-      group   => 'root',
-      mode    => $mapperms,
-      replace => $replace,
-      require => Package[ 'autofs' ],
-      notify  => Service[ 'autofs' ],
-    }
-    concat::fragment{"${mapfile}_entries":
-      target  => $mapfile,
-      content => template($maptempl),
-      order   => 1,
+    autofs::map { $title:
+      mapfile    => $mapfile,
+      mapcontent => $mapcontents,
+      replace    => $replace,
+      template   => $maptempl,
+      mapmode    => $mapperms,
     }
   }
 }

--- a/spec/acceptance/autofs_init_spec.rb
+++ b/spec/acceptance/autofs_init_spec.rb
@@ -222,11 +222,10 @@ describe 'autofs' do
         it { is_expected.not_to be_running }
       end
 
-      # Skipped until we can pinpoint why serverspec
-      # doesn't properly check if an Upstart service
-      # is enabled or not
-      describe service('autofs') do
-        xit { is_expected.not_to be_enabled }
+      unless default[:platform] =~ %r{ubuntu-14.04-amd64}
+        describe service('autofs') do
+          it { is_expected.not_to be_enabled }
+        end
       end
     end
   end

--- a/spec/acceptance/autofs_map_spec.rb
+++ b/spec/acceptance/autofs_map_spec.rb
@@ -5,32 +5,14 @@ describe 'autofs::map  tests' do
     it 'applies' do
       pp = <<-EOS
         class { 'autofs': }
-        autofs::mount { 'data':
-          mount       => '/data',
+        autofs::map { 'datamap':
           mapfile     => '/etc/auto.data',
-          mapcontents => ['dataB -o rw /mnt/dataB'],
-          options     => '--timeout=120',
-          order       => 01
+          mapcontent  => [ 'dataB -o rw /mnt/dataB', 'dataC -o rw /mnt/dataC' ],
         }
-	autofs::map {'dataC':
-	  mapfile => '/etc/auto.data',
-	  mapcontent => 'dataC -o rw /mnt/dataC',
-         }
       EOS
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
-    end
-
-    describe file('/etc/auto.master') do
-      it 'exists and have content' do
-        is_expected.to exist
-        is_expected.to be_owned_by 'root'
-        is_expected.to be_grouped_into 'root'
-        shell('cat /etc/auto.master') do |s|
-          expect(s.stdout).to match(%r{/data /etc/auto.data --timeout=120})
-        end
-      end
     end
 
     describe file('/etc/auto.data') do
@@ -39,7 +21,7 @@ describe 'autofs::map  tests' do
         is_expected.to be_owned_by 'root'
         is_expected.to be_grouped_into 'root'
         shell('cat /etc/auto.data') do |s|
-          expect(s.stdout).to match(%r{(dataA -o rw /mnt/dataA|dataC -o rw /mnt/dataC)})
+          expect(s.stdout).to match(%r{(dataB -o rw /mnt/dataA|dataC -o rw /mnt/dataC)})
         end
       end
     end

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -11,16 +11,20 @@ describe 'autofs::map', type: :define do
   let(:params) do
     {
       mapfile: '/etc/auto.data',
-      mapcontent: 'test foo bar',
-      order: 0o1
+      mapcontent: ['test foo bar'],
     }
   end
 
   context 'with default parameters' do
     it do
-      is_expected.to contain_concat__fragment('/etc/auto.data_test foo bar').with(
+      is_expected.to contain_concat('/etc/auto.data').with(
+        'ensure' => 'present',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644'
+      )
+      is_expected.to contain_concat__fragment('/etc/auto.data_entries').with(
         'target' => '/etc/auto.data',
-        'content' => "test foo bar\n"
       )
     end
   end

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -11,7 +11,7 @@ describe 'autofs::map', type: :define do
   let(:params) do
     {
       mapfile: '/etc/auto.data',
-      mapcontent: ['test foo bar'],
+      mapcontent: ['test foo bar']
     }
   end
 
@@ -24,7 +24,7 @@ describe 'autofs::map', type: :define do
         'mode'   => '0644'
       )
       is_expected.to contain_concat__fragment('/etc/auto.data_entries').with(
-        'target' => '/etc/auto.data',
+        'target' => '/etc/auto.data'
       )
     end
   end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -14,7 +14,7 @@ describe 'autofs::mount', type: :define do
       mapfile: '/etc/auto.home',
       mapcontents: %w[test foo bar],
       options: '--timeout=120',
-      order: 01,
+      order: 1,
       master: '/etc/auto.master'
     }
   end
@@ -46,7 +46,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: %w[test foo bar],
         options: '--timeout=120',
-        order: 01,
+        order: 1,
         direct: false
       }
     end
@@ -63,7 +63,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: ['/home /test', '/home /foo', '/home /bar'],
         options: '--timeout=120',
-        order: 0o1,
+        order: 1,
         direct: true
       }
     end
@@ -81,7 +81,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: %w[test foo bar],
         options: '--timeout=120',
-        order: 01,
+        order: 1,
         map_dir: '/etc/auto.master.d',
         use_dir: true
       }
@@ -122,7 +122,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: %w[test foo bar],
         options: '--timeout=120',
-        order: 01,
+        order: 1,
         execute: true
       }
     end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -14,7 +14,7 @@ describe 'autofs::mount', type: :define do
       mapfile: '/etc/auto.home',
       mapcontents: %w[test foo bar],
       options: '--timeout=120',
-      order: 0o1,
+      order: 01,
       master: '/etc/auto.master'
     }
   end
@@ -35,6 +35,7 @@ describe 'autofs::mount', type: :define do
       is_expected.to contain_concat__fragment('/etc/auto.home_entries').with(
         'target' => '/etc/auto.home'
       )
+      is_expected.to contain_autofs__map('auto.home')
     end
   end
 
@@ -45,7 +46,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: %w[test foo bar],
         options: '--timeout=120',
-        order: 0o1,
+        order: 01,
         direct: false
       }
     end
@@ -80,7 +81,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: %w[test foo bar],
         options: '--timeout=120',
-        order: 0o1,
+        order: 01,
         map_dir: '/etc/auto.master.d',
         use_dir: true
       }
@@ -121,7 +122,7 @@ describe 'autofs::mount', type: :define do
         mapfile: '/etc/auto.home',
         mapcontents: %w[test foo bar],
         options: '--timeout=120',
-        order: 0o1,
+        order: 01,
         execute: true
       }
     end

--- a/templates/auto.map.erb
+++ b/templates/auto.map.erb
@@ -14,6 +14,6 @@
 ###############################################################
 <% end -%>
 
-<% @mapcontents.each do |content| -%>
+<% @mapcontent.each do |content| -%>
 <%= content %>
 <% end -%>

--- a/templates/auto.map.exec.erb
+++ b/templates/auto.map.exec.erb
@@ -15,6 +15,6 @@
 ###############################################################
 <% end -%>
 
-<% @mapcontents.each do |content| -%>
+<% @mapcontent.each do |content| -%>
 <%= content %>
 <% end -%>


### PR DESCRIPTION
Moved all mapfile generation to the map defined type provided by
@traylenator and instead have the mount defined type calling and passing
values to the map defined type (if mapfile is not empty).

This allows all current functionality to continue working, as well as,
allowing the map defined type to be used standalone AND maintain the
existing mapfile generation feature set.

Tests and templates have been updated to account for the changes.

closes #59 
