### PR TITLE
Multiple autofs::map instances per map.

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -32,7 +32,7 @@ define autofs::map (
   Integer $order                                                    = 1,
 ) {
 
-  concat { $mapfile:
+  ensure_resource(concat,$mapfile,{
     ensure  => present,
     owner   => 'root',
     group   => 'root',
@@ -40,9 +40,9 @@ define autofs::map (
     replace => $replace,
     require => Package['autofs'],
     notify  => Service['autofs'],
-  }
+  })
 
-  concat::fragment{"${mapfile}_entries":
+  concat::fragment{"${mapfile}_${name}_entries":
     target  => $mapfile,
     content => template($template),
     order   => $order,

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -23,7 +23,7 @@ describe 'autofs::map', type: :define do
         'group'  => 'root',
         'mode'   => '0644'
       )
-      is_expected.to contain_concat__fragment('/etc/auto.data_entries').with(
+      is_expected.to contain_concat__fragment('/etc/auto.data_data_entries').with(
         'target' => '/etc/auto.data'
       )
     end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -32,7 +32,7 @@ describe 'autofs::mount', type: :define do
         'group'  => 'root',
         'mode'   => '0644'
       )
-      is_expected.to contain_concat__fragment('/etc/auto.home_entries').with(
+      is_expected.to contain_concat__fragment('/etc/auto.home_auto.home_entries').with(
         'target' => '/etc/auto.home'
       )
       is_expected.to contain_autofs__map('auto.home')


### PR DESCRIPTION
Now possible to specify two map instances
for the same map.

```puppet
autofs::map{'dataA':
 map         => '/etc/auto.data',
 mapcontent => ['dataA -rw nfs.example.org:/dataA'],
}
autofs::map{'dataB':
 map         => '/etc/auto.data',
 mapcontent => ['dataB nfs.example.org:/dataB'],
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
