### PR TITLE
Fixes #63 autofs::map mapcontent parameter to  mapcontents

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Define:
 ```puppet
 autofs::map{'data':
   map => '/etc/auto.data',
-  mapcontent => 'data -user,rw,soft server.example.com:/path/to/data,
+  mapcontents => 'data -user,rw,soft server.example.com:/path/to/data,
 }
 ```
 

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -13,18 +13,18 @@
 #
 # @example Using the autofs::map defined type to setup automount for nfs data directory.
 #   autofs::map { 'data':
-#     mapcontent => 'mydata -user,rw,soft,intr,rsize=32768,wsize=32768  nfs.example.org:/path/to/some/data',
+#     mapcontents => 'mydata -user,rw,soft,intr,rsize=32768,wsize=32768  nfs.example.org:/path/to/some/data',
 #     mapfile => '/etc/auto.data',
 #     order   => '01',
 #   }
 #
-# @param mapcontent The mount point options and parameters, 
+# @param mapcontents The mount point options and parameters, 
 #   Example: '* -user,rw,soft nfs.example.org:/path/to'
 # @param mapfile Name of the "auto." configuration file that will be generated.
 # @param order Order in which entries will appear in the autofs map file.
 
 define autofs::map (
-  Array $mapcontent,
+  Array $mapcontents,
   Stdlib::Absolutepath $mapfile,
   Enum['autofs/auto.map.erb', 'autofs/auto.map.exec.erb'] $template = 'autofs/auto.map.erb',
   String $mapmode                                                   = '0644',

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -116,11 +116,11 @@ define autofs::mount (
 
   if $mapfile and $mapfile_manage {
     autofs::map { $title:
-      mapfile    => $mapfile,
-      mapcontent => $mapcontents,
-      replace    => $replace,
-      template   => $maptempl,
-      mapmode    => $mapperms,
+      mapfile     => $mapfile,
+      mapcontents => $mapcontents,
+      replace     => $replace,
+      template    => $maptempl,
+      mapmode     => $mapperms,
     }
   }
 }

--- a/spec/acceptance/autofs_map_spec.rb
+++ b/spec/acceptance/autofs_map_spec.rb
@@ -7,7 +7,7 @@ describe 'autofs::map  tests' do
         class { 'autofs': }
         autofs::map { 'datamapA':
           mapfile     => '/etc/auto.data',
-          mapcontent  => [ 'dataA -o rw /mnt/dataA', 'dataB -o rw /mnt/dataB' ],
+          mapcontents => [ 'dataA -o rw /mnt/dataA', 'dataB -o rw /mnt/dataB' ],
         }
       EOS
 
@@ -40,11 +40,11 @@ describe 'autofs::map  tests' do
         class { 'autofs': }
         autofs::map { 'datamapA':
           mapfile     => '/etc/auto.data',
-          mapcontent  => [ 'dataA -o rw /mnt/dataA', 'dataB -o rw /mnt/dataB' ],
+          mapcontents => [ 'dataA -o rw /mnt/dataA', 'dataB -o rw /mnt/dataB' ],
         }
         autofs::map { 'datamapB':
           mapfile     => '/etc/auto.data',
-          mapcontent  => [ 'dataC -o rw /mnt/dataC', 'dataD -o rw /mnt/dataD' ],
+          mapcontents => [ 'dataC -o rw /mnt/dataC', 'dataD -o rw /mnt/dataD' ],
         }
       EOS
 

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -61,7 +61,7 @@ describe 'autofs', type: :class do
     it 'is expected to have auto.home hiera values' do
       expect(maps).to include(
         'mapfile' => '/etc/auto.home',
-        'mapcontent' => '/home /another'
+        'mapcontents' => '/home /another'
       )
     end
   end

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -11,7 +11,7 @@ describe 'autofs::map', type: :define do
   let(:params) do
     {
       mapfile: '/etc/auto.data',
-      mapcontent: ['test foo bar']
+      mapcontents: ['test foo bar']
     }
   end
 

--- a/spec/fixtures/hiera/test.yaml
+++ b/spec/fixtures/hiera/test.yaml
@@ -10,7 +10,7 @@ homedir:
     order: 01
 homedir_maps:
     mapfile: '/etc/auto.home'
-    mapcontent: '/home /another'
+    mapcontents: '/home /another'
 direct:
     mount: '/-'
     mapfile: '/etc/auto.home'

--- a/templates/auto.map.erb
+++ b/templates/auto.map.erb
@@ -14,6 +14,6 @@
 ###############################################################
 <% end -%>
 
-<% @mapcontent.each do |content| -%>
+<% @mapcontents.each do |content| -%>
 <%= content %>
 <% end -%>

--- a/templates/auto.map.exec.erb
+++ b/templates/auto.map.exec.erb
@@ -15,6 +15,6 @@
 ###############################################################
 <% end -%>
 
-<% @mapcontent.each do |content| -%>
+<% @mapcontents.each do |content| -%>
 <%= content %>
 <% end -%>


### PR DESCRIPTION
The recently added `autofs::map type had a parameter `mapcontent`.
To be consistant with the existing `mapcontents` paramter
to `autofs::mount` we should use the plural `mapcontents`.

No release has been made with `autofs::map` so this is
not a breaking change.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
