### PR TITLE
Specify default for order parameter on auto::mount

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -50,7 +50,7 @@
 #
 define autofs::mount (
   Stdlib::Absolutepath $mount,
-  Integer              $order,
+  Integer $order                          = 1,
   Optional[Variant[Stdlib::Absolutepath,Autofs::Mapentry]] $mapfile = undef,
   Optional[String] $options               = '',
   Stdlib::Absolutepath $master            = '/etc/auto.master',

--- a/spec/acceptance/autofs_two_indirect_spec.rb
+++ b/spec/acceptance/autofs_two_indirect_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper_acceptance'
+
+describe 'autofs::mount indirect tests' do
+  context 'two indirect test, order not specified' do
+    it 'applies' do
+      pp = <<-EOS
+        class { 'autofs': }
+        autofs::mount { 'foo':
+          mount       => '/foo',
+          mapfile     => '/etc/auto.foo',
+          mapcontents => ['FOO -o rw /mnt/test_FOO'],
+          options     => '--timeout=120',
+        }
+        autofs::mount { 'bar':
+          mount       => '/bar',
+          mapfile     => '/etc/auto.bar',
+          mapcontents => ['BAR -o rw /mnt/test_BAR'],
+          options     => '--timeout=240',
+        }
+
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.master') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to contain '/foo /etc/auto.foo --timeout=120'
+        is_expected.to contain '/bar /etc/auto.bar --timeout=240'
+      end
+    end
+
+    describe file('/etc/auto.foo') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to contain 'FOO -o rw /mnt/test_FOO'
+      end
+    end
+
+    describe file('/etc/auto.bar') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to contain 'BAR -o rw /mnt/test_BAR'
+      end
+    end
+
+    describe package('autofs') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('autofs') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+end


### PR DESCRIPTION
The `order` parameter to `auto::mount`

```puppet
auto::mount{'home':
  mount   => '/home',
  mapfile => '/etc/auto.home',
  order   => 3,
  ...
}
```
currently must be specified.

Especially since in the vast majority of cases the order of the lines
in `/etc/auto.master` is irrelevent a default this value can be specified.

Motification, less mandatory options always good.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
