### PR TITLE
Let `autofs::mount` mount option default to title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Data type: Stblib::Absolutepath
 
 This Mapping describes where autofs will be mounting to. This map
 entry is referenced by concat as part of the generation of the /etc/auto.master
-file.
+file. Defaults to the `title` of the `autofs::mount`
 
 #### `mapfile`
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -49,7 +49,7 @@
 # @param replace Set to false if you only want to place the file if it is missing.
 #
 define autofs::mount (
-  Stdlib::Absolutepath $mount,
+  Stdlib::Absolutepath $mount             = $title,
   Integer $order                          = 1,
   Optional[Variant[Stdlib::Absolutepath,Autofs::Mapentry]] $mapfile = undef,
   Optional[String] $options               = '',


### PR DESCRIPTION
```puppet
autofs::mount{'data':
  mount   => '/data',
  mapfile => '/etc/auto.data',
  ...
}
```

can now be specified as

```puppet
autofs::mount{'/data':
  mapfile => '/etc/auto.data',
  ...
}
```

Given the mount point has to be a unique key in the `/etc/auto.master`
anyway this makes sense.

Backwards compatible anyway of course.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
