### PR TITLE
Support map types in auto.master

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,12 @@ file.
 
 #### `mapfile`
 
-Data type: Stdlib::Absolutepath
+Data type: Stdlib::Absolutepath or Autofs::MapEntry
 
 This Mapping describes the name and path of the autofs map file.
 This mapping is used in the auto.master generation, as well as generating the map
 file from the auto.map.erb template. This parameter is no longer required.
+When anything other than a simple file path is used `mapfile_manage` must be false.
 
 #### `mapfile_manage`
 

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -56,6 +56,40 @@ describe 'autofs::mount', type: :define do
     end
   end
 
+  context 'with unmanged maptype specified' do
+    let(:params) do
+      {
+        mount: '/smb',
+        mapfile: 'program:/etc/auto.smb',
+        mapfile_manage: false,
+        options: '--timeout=120',
+        order: 2,
+        direct: false
+      }
+    end
+
+    it do
+      is_expected.not_to contain_file('/etc/auto.smb')
+    end
+  end
+
+  context 'with manged maptype' do
+    let(:params) do
+      {
+        mount: '/smb',
+        mapfile: 'program:/etc/auto.smb',
+        mapfile_manage: true,
+        options: '--timeout=120',
+        order: 2,
+        direct: false
+      }
+    end
+
+    it 'is expected to fail' do
+      is_expected.to compile.and_raise_error(%r{Parameter 'mapfile_manage' must be false for complicated})
+    end
+  end
+
   context 'with indirect map' do
     let(:params) do
       {

--- a/types/mapentry.pp
+++ b/types/mapentry.pp
@@ -1,0 +1,6 @@
+# This type matches a map type and path.
+# @example program:/etc/auto.smb
+# @example file:/etc/auto.file
+
+type Autofs::Mapentry = Pattern[/^[a-z]+:\/([^\/\0]+(\/)?)+$/]
+


### PR DESCRIPTION
It is desirable to be able to configure map types.

/smb program:/etc/auto.smb

```puppet
mount{'smb':
  mount          => '/smb',
  mapfile        => 'program:/etc/auto.smb',
  mapfile_manage => false,
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
