### PR TITLE
Confine autofs_version fact to Linux kernel.

### DIFF
--- a/lib/facter/autofs.rb
+++ b/lib/facter/autofs.rb
@@ -1,4 +1,5 @@
 Facter.add(:autofs_version) do
+  confine kernel: 'Linux'
   setcode do
     if Facter::Util::Resolution.which('automount')
       autofs_version_command = 'automount -V 2>&1'


### PR DESCRIPTION
Fixes #68

https://github.com/voxpupuli/puppet-autofs/issues/68


