### PR TITLE
bump minimal puppet version to 4.7.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -91,7 +91,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
this is the supported LTS version for 4.X from Puppet. We agreed to not
support anything that is older.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
