### PR TITLE
BREAKING: refactor hiera data lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,28 @@ autofs::mounts:
     order: 01
 ```
 
+If you need to merge the `autofs::mounts` key from multiple files or hiera lookups, be sure to add the `lookup_options`
+key and set the merge behavior for `autofs::mounts` to `merge: hash`
+
+```yaml
+lookup_options:
+  autofs::mounts:
+    merge: hash
+autofs::mounts:
+  home:
+    mount: '/home'
+    mapfile: '/etc/auto.home'
+    mapcontents:
+      - '* -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl server.example.com:/path/to/home/shares'
+    options: '--timeout=120'
+    order: 01
+```
+
+For more information about merge behavior see the doc for:
+
+* [Lookup docs](https://docs.puppet.com/puppet/4.7/lookup_quick.html#puppet-lookup:-quick-reference-for-hiera-users) 
+* [Hiera 5 docs](https://docs.puppet.com/puppet/5.1/hiera_merging.html) if using Puppet >= 4.9
+
 ##### Direct Map `/-` arugment
 
 The autofs module also supports the use of the built in autofs `/-` argument used with Direct Maps.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,8 +74,8 @@
 #   on boot.
 #
 class autofs (
-  Optional[Hash] $mounts                       = undef,
-  Optional[Hash] $maps                         = undef,
+  Hash[String, Hash] $mounts                   = {},
+  Hash[String, Hash] $maps                     = {},
   String $package_ensure                       = 'installed',
   Enum[ 'stopped', 'running' ] $service_ensure = 'running',
   Boolean $service_enable                      = true,
@@ -85,12 +85,11 @@ class autofs (
     contain '::autofs::service'
   }
 
-  if $mounts {
-    $data = hiera_hash('autofs::mounts', $mounts)
-    create_resources('autofs::mount', $data)
+  $mounts.each |String $mount, Hash $attributes| {
+    autofs::mount { $mount: * => $attributes }
   }
-  if $maps {
-    $_datamaps = hiera_hash('autofs::maps', $maps)
-    create_resources('autofs::map',$_datamaps)
+
+  $maps.each |String $map, Hash $attributes| {
+    autofs::map { $map: * => $attributes }
   }
 }

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -102,7 +102,7 @@ describe 'autofs', type: :class do
     let(:params) { { mounts: mounts } }
 
     it 'is expected to fail' do
-      is_expected.to compile.and_raise_error(%r{parameter 'mounts' expects a value of type Undef or Hash})
+      is_expected.to compile.and_raise_error(%r{parameter 'mounts' expects a Hash value})
     end
   end
 end


### PR DESCRIPTION
Replacing the deprecated hiera_hash functions with the lookup function. Additionally, I have replaced the `create_resources` function calls using the method found at https://docs.puppet.com/puppet/5.1/lang_resources_advanced.html#implementing-the-createresources-function

That replacement gives users and contributors alike a better idea as to what the code is actually doing when generating the defined resources.