### PR TITLE
 Fix spec test for autofs_version fact

### DIFF
--- a/lib/facter/autofs_version.rb
+++ b/lib/facter/autofs_version.rb
@@ -1,12 +1,10 @@
 Facter.add(:autofs_version) do
-  unless :osfamily == 'Solaris'
-    confine kernel: 'Linux'
-    setcode do
-      if Facter::Util::Resolution.which('automount')
-        autofs_version_command = 'automount -V 2>&1'
-        autofs_version = Facter::Core::Execution.execute(autofs_version_command)
-        %r{Linux automount version ([\w\.]+)}.match(autofs_version)[1]
-      end
+  confine kernel: :Linux
+  setcode do
+    if Facter::Util::Resolution.which('automount')
+      autofs_version_command = 'automount -V 2>&1'
+      autofs_version = Facter::Core::Execution.execute(autofs_version_command)
+      %r{Linux automount version ([\w\.]+)}.match(autofs_version)[1]
     end
   end
 end


### PR DESCRIPTION
This was already pulled in in #78 but just a couple updates here, and adding this as a separate commit for the history.

