### PR TITLE
Add ability to remove mounts and maps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ In addition to adding map entries via the `mapcontents` parameter to `autofs::mo
 Define:
 ```puppet
 autofs::map{'data':
-  map => '/etc/auto.data',
+  map         => '/etc/auto.data',
   mapcontents => 'data -user,rw,soft server.example.com:/path/to/data,
 }
 ```
@@ -224,6 +224,47 @@ autofs::mount{'auto.data':
   mount   => '/big',
 }
 ```
+
+##### Removing Entries
+
+To remove entries from a `mapfile` simply remove the element from the `mapcontents` array in your `manifest` or `hiera` data.
+
+Example:
+
+```puppet
+autofs::map {'data':
+  map         => '/etc/auto.data',
+  mapcontents => [ 'dataA -o rw /mnt/dataA', 'dataB -o rw /mnt/dataB' ]
+}
+```
+
+```yaml
+autofs::maps:
+  data:
+    map: '/etc/auto.data'
+    mapcontents:
+      - 'dataA -o rw /mnt/dataA'
+      - 'dataB -o rw /mnt/dataB'
+```
+
+To remove the `dataA` entry from the `/etc/auto.data`, simply remove that array element:
+
+```puppet
+autofs::map {'data':
+  map         => '/etc/auto.data',
+  mapcontents => [ 'dataB -o rw /mnt/dataB' ]
+}
+```
+
+```yaml
+autofs::maps:
+  data:
+    map: '/etc/auto.data'
+    mapcontents:
+      - 'dataB -o rw /mnt/dataB'
+```
+
+**NOTE: Do NOT set `ensure => 'absent'` as that removes the entire `mapfile`**
 
 
 ## Reference
@@ -291,6 +332,14 @@ Data type: String
 
 This is a logical, descriptive name for what what autofs will be
 mounting. This is represented by the `home:` and `tmp:` entries above.
+
+#### `ensure`
+
+Data type: String
+
+Ensure the state of the mount content. If set to `absent` it will remove any `concat::fragments` 
+with the `name` matching `'autofs::fragment preamble <mount> <mapfile>"`, as well as any `autofs::maps`
+created by that `autofs::mount` resource. Defaults to `present`.
 
 #### `mount`
 
@@ -397,6 +446,13 @@ Whether or not to replace the mapfile if it already exists.
 Default: `true`
 
 ### Parameters for autofs::map
+
+#### `ensure`
+
+Data type: String
+
+Ensures the state of the `mapfile`. Setting to `absent` **WILL REMOVE THE MAPFILE**, if you just
+to remove an entry in the `mapfile`, remove the `mapcontents` string or array element you want to remove.
 
 #### `mapfile`
 

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -18,6 +18,7 @@
 #     order   => '01',
 #   }
 #
+# @param ensure Whether to create the mapfile or not.
 # @param mapcontents The mount point options and parameters, 
 #   Example: '* -user,rw,soft nfs.example.org:/path/to'
 # @param mapfile Name of the "auto." configuration file that will be generated.
@@ -27,12 +28,13 @@
 # @param order Order in which entries will appear in the autofs map file.
 #
 define autofs::map (
-  Array $mapcontents,
-  Stdlib::Absolutepath $mapfile,
+  Enum['present', 'absent'] $ensure                                 = 'present',
+  Stdlib::Absolutepath $mapfile                                     = $title,
   Enum['autofs/auto.map.erb', 'autofs/auto.map.exec.erb'] $template = 'autofs/auto.map.erb',
   String $mapmode                                                   = '0644',
   Boolean $replace                                                  = true,
   Integer $order                                                    = 1,
+  Optional[Array] $mapcontents                                      = undef,
 ) {
   include '::autofs'
 
@@ -43,7 +45,7 @@ define autofs::map (
   }
 
   ensure_resource(concat,$mapfile,{
-    ensure  => present,
+    ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
     mode    => $mapmode,
@@ -51,10 +53,12 @@ define autofs::map (
     require => Class['autofs::package'],
   })
 
-  concat::fragment{"${mapfile}_${name}_entries":
-    target  => $mapfile,
-    content => template($template),
-    order   => $order,
+  unless $ensure == 'absent' {
+    concat::fragment { "${mapfile}_${name}_entries":
+      target  => $mapfile,
+      content => template($template),
+      order   => $order,
+    }
   }
 
 }

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -34,7 +34,7 @@ define autofs::map (
   String $mapmode                                                   = '0644',
   Boolean $replace                                                  = true,
   Integer $order                                                    = 1,
-  Optional[Array] $mapcontents                                      = undef,
+  Variant[Array, String] $mapcontents                               = [],
 ) {
   include '::autofs'
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -67,7 +67,7 @@ define autofs::mount (
   Boolean $direct                         = true,
   Boolean $execute                        = false,
   Boolean $mapfile_manage                 = true,
-  Array $mapcontents                      = [],
+  Variant[Array, String] $mapcontents     = [],
   Boolean $replace                        = true
 ) {
   include '::autofs'

--- a/spec/acceptance/autofs_init_spec.rb
+++ b/spec/acceptance/autofs_init_spec.rb
@@ -113,6 +113,35 @@ describe 'autofs' do
       include_examples 'basic tests'
     end
 
+    context 'without home map' do
+      it 'applies' do
+        pp = <<-MANIFEST
+          class { 'autofs':
+            mounts => {
+              'home' => {
+                ensure  => 'absent',
+                mount   => '/home',
+                mapfile => '/etc/auto.home',
+              }
+            }
+          }
+        MANIFEST
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file('/etc/auto.master') do
+        it do
+          is_expected.to exist
+          is_expected.to be_file
+          is_expected.to be_owned_by 'root'
+          is_expected.to be_grouped_into 'root'
+        end
+
+        its(:content) { is_expected.not_to contain("/home /etc/auto.home \n") }
+      end
+    end
+
     context 'master directory test' do
       before(:context) do
         cleanup_helper

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -97,6 +97,18 @@ describe 'autofs', type: :class do
     end
   end
 
+  context 'should remove the mount' do
+    mounts = hiera.lookup('rmdir', nil, nil)
+    let(:params) { { mounts: mounts } }
+
+    it 'is expected to remove the mount' do
+      expect(mounts).to include(
+        'ensure'  => 'absent',
+        'mapfile' => '/etc/auto.home'
+      )
+    end
+  end
+
   context 'Parameter is not a hash' do
     mounts = 'string'
     let(:params) { { mounts: mounts } }

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -240,6 +240,43 @@ describe 'autofs::mount', type: :define do
           is_expected.not_to contain_file('/data').with('ensure' => 'directory')
         end
       end
+
+      context 'with special -hosts map' do
+        let(:title) { 'auto.NET' }
+        let(:params) do
+          {
+            mount: '/net',
+            mapfile_manage: false,
+            mapfile: '-hosts'
+          }
+        end
+
+        it do
+          is_expected.to contain_concat('/etc/auto.master')
+          is_expected.to contain_concat__fragment('autofs::fragment preamble /net -hosts').with_target('/etc/auto.master')
+        end
+      end
+
+      context 'with ensure set to absent' do
+        let(:title) { '/data' }
+        let(:params) do
+          {
+            ensure: 'absent',
+            mapfile: '/etc/auto.data'
+          }
+        end
+
+        it do
+          is_expected.to contain_file_line('remove_contents_/data_/etc/auto.data').with(
+            ensure: 'absent',
+            path: '/etc/auto.master',
+            match: "^/data /etc/auto.data \n"
+          )
+          is_expected.not_to contain_concat__fragment('autofs::fragment preamble /data /etc/auto.data')
+          is_expected.to contain_concat('/etc/auto.data').with_ensure('absent')
+          is_expected.not_to contain_concat__fragment('/etc/auto.data_/data_entries')
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/hiera/test.yaml
+++ b/spec/fixtures/hiera/test.yaml
@@ -37,3 +37,6 @@ autofs::mounts:
     options: '--timeout=120'
     order: 01
     use_dir: true
+rmdir:
+    ensure: 'absent'
+    mapfile: '/etc/auto.home'


### PR DESCRIPTION
closes #91 

Important note: This will remove entire `autofs::map` mapfiles. 

If you want to remove just the content of a `mapfile` either through an `autofs::mount` or `autofs::map`, simply remove the content from the `mapcontents` parameter in either defined type.