### PR TITLE
Fix Issue-96 Add AIX Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Compatible with Puppet 4 only. Puppet 4.6.0 will provide best results.
       * 8 "Jessie"
 * Self Support - should work, support not provided by developer
     * Solaris 10, 11
+    * AIX 7.1, 7.2
     * Fedora 24, 25
     * SLES 10
     * CentOS/RHEL/Scientific/Oracle Linux 5.x

--- a/data/AIX.yaml
+++ b/data/AIX.yaml
@@ -1,0 +1,6 @@
+---
+autofs::service_name: automountd
+autofs::package_name: bos.net.nfs.client # NOTE: It seems to be already installed
+autofs::auto_master_map: /etc/auto_master
+autofs::map_file_group: system
+autofs::reload_command: /usr/sbin/automount -v

--- a/data/Solaris-11.yaml
+++ b/data/Solaris-11.yaml
@@ -1,0 +1,2 @@
+---
+autofs::package_name: system/file-system/autofs

--- a/data/Solaris.yaml
+++ b/data/Solaris.yaml
@@ -1,0 +1,5 @@
+---
+autofs::package_name: ['SUNWatfsr', 'SUNWatfsu']
+autofs::auto_master_map: /etc/auto_master
+#autofs::map_file_group: bin # root group exists, but it is bin by default
+autofs::reload_command: /usr/sbin/automount -v

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,13 @@
+---
+autofs::mounts: {}
+autofs::maps: {}
+autofs::package_ensure: installed
+autofs::package_name: autofs
+autofs::package_source: null
+autofs::service_ensure: running
+autofs::service_enable: true
+autofs::service_name: autofs
+autofs::auto_master_map: /etc/auto.master
+autofs::map_file_owner: root
+autofs::map_file_group: root
+autofs::reload_command: null

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,11 @@
+version: 5
+defaults:
+  data_hash: yaml_data
+  datadir: data
+hierarchy:
+  - name: "OS Family - Major Version"
+    path: "%{facts.os.family}-%{facts.os.release.major}.yaml"
+  - name: "OS Family"
+    path: "%{facts.os.family}.yaml"
+  - name: "Common values"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,17 +68,31 @@
 # @option maps [Boolean] :replace Replace the file if it changes or not.
 # @option maps [Integer] :order The order in which to place mapfile contents.
 # @param package_ensure Determines the state of the package. Can be set to: installed, absent, lastest, or a specific version string.
+# @param package_name Determine the name of the package to install. Should be covered by hieradata.
+# @param package_source Determine the source of the package, required on certain platforms (AIX)
 # @param service_ensure Determines state of the service. Can be set to: running or stopped.
 # @param service_enable Determines if the service should start with the system boot. true
 #   will start the autofs service on boot. false will not start the autofs service
 #   on boot.
+# @param service_name Determine the name of the service for cross platform compatibility
+# @param auto_master_map Filename of the auto.master map for cross platform compatiblity
+# @param map_file_owner owner of the automount map files for cross platform compatiblity
+# @param map_file_group group of the automount map files for cross platform compatiblity
+# @param reload_command In lieu of a service reload capability in Puppet, exec this command to reload automount without restarting it.
 #
 class autofs (
-  Hash[String, Hash] $mounts                   = {},
-  Hash[String, Hash] $maps                     = {},
-  String $package_ensure                       = 'installed',
-  Enum[ 'stopped', 'running' ] $service_ensure = 'running',
-  Boolean $service_enable                      = true,
+  Hash[String, Hash] $mounts,
+  Hash[String, Hash] $maps,
+  String $package_ensure,
+  Variant[String, Array[String]] $package_name,
+  Optional[String] $package_source,
+  Enum[ 'stopped', 'running' ] $service_ensure,
+  Boolean $service_enable,
+  String $service_name,
+  String $auto_master_map,
+  String $map_file_owner,
+  String $map_file_group,
+  Optional[String] $reload_command,
 ) {
   contain '::autofs::package'
   unless $package_ensure == 'absent' {

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -39,15 +39,22 @@ define autofs::map (
   include '::autofs'
 
   unless $::autofs::package_ensure == 'absent' {
-    Concat {
-      notify => Service['autofs'],
+    if $autofs::reload_command {
+      Concat {
+        before => Service[$autofs::service_name],
+        notify => Exec['automount-reload'],
+      }
+    } else {
+      Concat {
+        notify => Service[$autofs::service_name],
+      }
     }
   }
 
   ensure_resource(concat,$mapfile,{
     ensure  => $ensure,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $autofs::map_file_owner,
+    group   => $autofs::map_file_group,
     mode    => $mapmode,
     replace => $replace,
     require => Class['autofs::package'],

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -23,24 +23,11 @@
 #
 class autofs::package {
   assert_private('Package class is private, please use main class parameters')
-  Package {
-    ensure => $::autofs::package_ensure,
-  }
-  case $facts['os']['family'] {
-    'Debian', 'Ubuntu': {
-      package { 'autofs': }
-    }
-    'RedHat', 'CentOS': {
-      package { 'autofs': }
-    }
-    'Suse': {
-      package { 'autofs': }
-    }
-    'Solaris': {
-      # Already installed in Solaris
-    }
-    default: {
-      fail("${facts['operatingsystem']} not supported.")
+
+  if $autofs::package_name {
+    package { $autofs::package_name:
+      ensure => $::autofs::package_ensure,
+      source => $autofs::package_source,
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,11 +18,20 @@
 #
 class autofs::service {
   assert_private('Service class is private, please use main class parameters.')
-  service { 'autofs':
+  service { $autofs::service_name:
     ensure     => $autofs::service_ensure,
     enable     => $autofs::service_enable,
     hasstatus  => true,
     hasrestart => true,
     require    => Class['autofs::package'],
+  }
+
+  if $autofs::reload_command {
+    exec { 'automount-reload':
+      path        => '/sbin:/usr/sbin',
+      command     => $autofs::reload_command,
+      refreshonly => true,
+      require     => Service[$autofs::service_name],
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,13 @@
         "10",
         "11"
       ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "7.1",
+        "7.2"
+      ]
     }
   ],
   "requirements": [

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 describe 'autofs::map', type: :define do
   on_supported_os.each do |os, facts|
+    let(:pre_condition) { 'include autofs' }
+
+    group = if facts[:os]['family'] == 'AIX'
+              'system'
+            else
+              'root'
+            end
+
     context "on #{os}" do
       let(:title) { 'data' }
       let(:facts) do
@@ -19,7 +27,7 @@ describe 'autofs::map', type: :define do
           is_expected.to contain_concat('/etc/auto.data').with(
             'ensure' => 'present',
             'owner'  => 'root',
-            'group'  => 'root',
+            'group'  => group,
             'mode'   => '0644'
           )
           is_expected.to contain_concat__fragment('/etc/auto.data_data_entries').with(


### PR DESCRIPTION
This fixes Issue-96, providing AIX support. NOTE that we enabled module level hiera to provide OSFAMILY specific data. We also put in a basic workaround for the "reload" of automount. Currently, at least on AIX, the service provider ignores the custom `restart` command.

NOTE: I did my best on the tests. I was not able to use PDK to validate the tests because your gemfile has binary requirements, which I cannot compile on my "work" computer. Let me know if they need fixed.

Thanks in advance,
Tommy