### PR TITLE
Fixed handling for bare-string mapcontents

### DIFF
--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -35,6 +35,17 @@ describe 'autofs::map', type: :define do
           )
         end
       end
+
+      context 'with bare string mapcontents' do
+        let(:params) do
+          {
+            mapfile: '/etc/auto.data',
+            mapcontents: 'test foo bar'
+          }
+        end
+
+        it { is_expected.to compile }
+      end
     end
   end
 end

--- a/templates/auto.map.erb
+++ b/templates/auto.map.erb
@@ -14,6 +14,6 @@
 ###############################################################
 <% end -%>
 
-<% @mapcontents.each do |content| -%>
+<% [@mapcontents].flatten.each do |content| -%>
 <%= content %>
 <% end -%>

--- a/templates/auto.map.exec.erb
+++ b/templates/auto.map.exec.erb
@@ -15,6 +15,6 @@
 ###############################################################
 <% end -%>
 
-<% @mapcontents.each do |content| -%>
+<% [@mapcontents].flatten.each do |content| -%>
 <%= content %>
 <% end -%>


### PR DESCRIPTION
The data type for the 'macontents' parameters of autofs::mount and
autofs::map permits both arrays and bare strings, and the documentation
is consistent with that, but catalog building failed when a bare string
is assigned to one of these parameters.  The bug was in the templates;
these are updated to handle the situation, and a unit test is added to
verify that it works.

Closes #108 