### PR TITLE
Make all drop-in files non-executable

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -151,7 +151,7 @@ define autofs::mount (
       ensure  => $ensure,
       owner   => $autofs::map_file_owner,
       group   => $autofs::map_file_group,
-      mode    => $mapperms,
+      mode    => '0644',
       content => $contents,
       require => File[$map_dir],
     }

--- a/spec/acceptance/autofs_exec_spec.rb
+++ b/spec/acceptance/autofs_exec_spec.rb
@@ -107,7 +107,6 @@ describe 'autofs::mount exec tests' do
       end
     end
 
-
     describe package('autofs') do
       it { is_expected.to be_installed }
     end

--- a/spec/acceptance/autofs_exec_spec.rb
+++ b/spec/acceptance/autofs_exec_spec.rb
@@ -24,8 +24,9 @@ describe 'autofs::mount exec tests' do
         is_expected.to exist
         is_expected.to be_owned_by 'root'
         is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
         shell('cat /etc/auto.master') do |s|
-          expect(s.stdout).to match(%r{/exec /etc/auto.exec --timeout=120})
+          expect(s.stdout).to match(%r{/exec /etc/auto[.]exec --timeout=120})
         end
       end
     end
@@ -35,11 +36,77 @@ describe 'autofs::mount exec tests' do
         is_expected.to exist
         is_expected.to be_owned_by 'root'
         is_expected.to be_grouped_into 'root'
-        shell('cat /etc/auto.exec') do |r|
-          expect(r.stdout).to match(%r{test_exec -o rw /mnt/test_exec})
-        end
+        is_expected.to be_mode 755
+      end
+      its(:content) do
+        is_expected.to start_with('#!/bin/bash')
+        is_expected.to match(%r{^test_exec -o rw /mnt/test_exec$})
       end
     end
+
+    describe package('autofs') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('autofs') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+
+  context 'exec with use_dir test' do
+    it 'applies' do
+      pp = <<-EOS
+        class { 'autofs': }
+        autofs::mount { 'exec':
+          mount       => '/exec',
+          mapfile     => '/etc/auto.exec',
+          mapcontents => [ 'test_exec -o rw /mnt/test_exec' ],
+          options     => '--timeout=120',
+          order       => 01,
+          execute     => true,
+          use_dir     => true,
+          map_dir     => '/etc/auto.master.d',
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.master') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) { is_expected.to match(%r{^[+]dir:/etc/auto[.]master[.]d$}) }
+    end
+
+    describe file('/etc/auto.master.d/exec.autofs') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) { is_expected.to match(%r{/exec /etc/auto[.]exec --timeout=120}) }
+    end
+
+    describe file('/etc/auto.exec') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 755
+      end
+      its(:content) do
+        is_expected.to start_with('#!/bin/bash')
+        is_expected.to match(%r{^test_exec -o rw /mnt/test_exec$})
+      end
+    end
+
 
     describe package('autofs') do
       it { is_expected.to be_installed }

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -140,48 +140,6 @@ describe 'autofs::mount', type: :define do
         end
       end
 
-      context 'with EL7 directory' do
-        let(:params) do
-          {
-            name: 'home',
-            mount: '/home',
-            mapfile: '/etc/auto.home',
-            mapcontents: %w[test foo bar],
-            options: '--timeout=120',
-            order: 1,
-            map_dir: '/etc/auto.master.d',
-            use_dir: true
-          }
-        end
-
-        it do
-          is_expected.to contain_concat__fragment('autofs::fragment preamble map directory')
-        end
-
-        it do
-          is_expected.to contain_file('/etc/auto.master.d').with(
-            'ensure' => 'directory',
-            'owner'  => 'root',
-            'group'  => group,
-            'mode'   => '0755'
-          )
-
-          is_expected.to contain_file('/etc/auto.master.d/home.autofs').with(
-            'ensure' => 'present',
-            'owner'  => 'root',
-            'group'  => group,
-            'mode'   => '0644'
-          )
-
-          is_expected.to contain_concat('/etc/auto.home').with(
-            'ensure' => 'present',
-            'owner'  => 'root',
-            'group'  => group,
-            'mode'   => '0644'
-          )
-        end
-      end
-
       context 'with executable map' do
         let(:params) do
           {
@@ -196,6 +154,51 @@ describe 'autofs::mount', type: :define do
 
         it do
           is_expected.to contain_concat('/etc/auto.home').with('mode' => '0755')
+        end
+      end
+
+      [true, false].each do |execute|
+        context "with EL7 directory and #{execute ? '' : 'non-'}executable map" do
+          let(:params) do
+            {
+              name: 'home',
+              mount: '/home',
+              mapfile: '/etc/auto.home',
+              mapcontents: %w[test foo bar],
+              options: '--timeout=120',
+              order: 1,
+              map_dir: '/etc/auto.master.d',
+              use_dir: true,
+              execute: execute
+            }
+          end
+
+          it do
+            is_expected.to contain_concat__fragment('autofs::fragment preamble map directory')
+          end
+
+          it do
+            is_expected.to contain_file('/etc/auto.master.d').with(
+              'ensure' => 'directory',
+              'owner'  => 'root',
+              'group'  => group,
+              'mode'   => '0755'
+            )
+
+            is_expected.to contain_file('/etc/auto.master.d/home.autofs').with(
+              'ensure' => 'present',
+              'owner'  => 'root',
+              'group'  => group,
+              'mode'   => '0644'
+            )
+
+            is_expected.to contain_concat('/etc/auto.home').with(
+              'ensure' => 'present',
+              'owner'  => 'root',
+              'group'  => group,
+              'mode'   => execute ? '0755' : '0644'
+            )
+          end
         end
       end
 


### PR DESCRIPTION
When an executable map was managed with use of a drop-in directory
($autofs::mount::use_dir == true), the drop-in file was made executable,
too.  This is fixed, and tested.

Closes #109 