### PR TITLE
Made the Autofs::Mapentry type more permissive

### DIFF
--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -274,6 +274,55 @@ describe 'autofs::mount', type: :define do
         end
       end
 
+      context 'with map format option' do
+        let(:title) { '/data' }
+        let(:params) do
+          {
+            mapfile: 'file,sun:/etc/auto.data',
+            mapfile_manage: false,
+          }
+        end
+
+        it do
+          is_expected.to compile
+          is_expected.to contain_concat(master_map_file)
+          is_expected.to contain_concat__fragment('autofs::fragment preamble /data file,sun:/etc/auto.data')
+            .with_target(master_map_file)
+            .with_content(%r{\A\s*/data\s+file,sun:/etc/auto.data\s*$})
+        end
+      end
+
+      context 'with map type and no leading slash' do
+        # this example is drawn directly from the Linux auto.master(5) manual page
+        let(:title) { '/mnt' }
+        let(:params) do
+          {
+            mapfile: 'yp:mnt.map',
+            mapfile_manage: false,
+          }
+        end
+
+        it do
+          is_expected.to compile
+          is_expected.to contain_concat(master_map_file)
+          is_expected.to contain_concat__fragment('autofs::fragment preamble /mnt yp:mnt.map')
+            .with_target(master_map_file)
+            .with_content(%r{\A\s*/mnt\s+yp:mnt.map\s*$})
+        end
+      end
+
+      context 'with relative map file' do
+        # This one expects compilation to fail
+        let(:title) { '/data' }
+        let(:params) do
+          {
+            mapfile: 'etc/auto.data',
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(/.*/) }
+      end
+
       context 'with ensure set to absent' do
         let(:title) { '/data' }
         let(:params) do

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -279,16 +279,16 @@ describe 'autofs::mount', type: :define do
         let(:params) do
           {
             mapfile: 'file,sun:/etc/auto.data',
-            mapfile_manage: false,
+            mapfile_manage: false
           }
         end
 
         it do
           is_expected.to compile
           is_expected.to contain_concat(master_map_file)
-          is_expected.to contain_concat__fragment('autofs::fragment preamble /data file,sun:/etc/auto.data')
-            .with_target(master_map_file)
-            .with_content(%r{\A\s*/data\s+file,sun:/etc/auto.data\s*$})
+          is_expected.to contain_concat__fragment('autofs::fragment preamble /data file,sun:/etc/auto.data').
+            with_target(master_map_file).
+            with_content(%r{\A\s*/data\s+file,sun:/etc/auto.data\s*$})
         end
       end
 
@@ -298,16 +298,16 @@ describe 'autofs::mount', type: :define do
         let(:params) do
           {
             mapfile: 'yp:mnt.map',
-            mapfile_manage: false,
+            mapfile_manage: false
           }
         end
 
         it do
           is_expected.to compile
           is_expected.to contain_concat(master_map_file)
-          is_expected.to contain_concat__fragment('autofs::fragment preamble /mnt yp:mnt.map')
-            .with_target(master_map_file)
-            .with_content(%r{\A\s*/mnt\s+yp:mnt.map\s*$})
+          is_expected.to contain_concat__fragment('autofs::fragment preamble /mnt yp:mnt.map').
+            with_target(master_map_file).
+            with_content(%r{\A\s*/mnt\s+yp:mnt.map\s*$})
         end
       end
 
@@ -316,11 +316,11 @@ describe 'autofs::mount', type: :define do
         let(:title) { '/data' }
         let(:params) do
           {
-            mapfile: 'etc/auto.data',
+            mapfile: 'etc/auto.data'
           }
         end
 
-        it { is_expected.to compile.and_raise_error(/.*/) }
+        it { is_expected.to compile.and_raise_error(%r{.*}) }
       end
 
       context 'with ensure set to absent' do

--- a/types/mapentry.pp
+++ b/types/mapentry.pp
@@ -1,6 +1,9 @@
-# This type matches a map type and path.
+# This type matches a map specfication with map type and optional format,
+# or the built-in -hosts map.
 # @example program:/etc/auto.smb
 # @example file:/etc/auto.file
-# @example hosts:-hosts
+# @example file,sun:/etc/auto.file
+# @example yp:mnt.map
+# @example -hosts
 
-type Autofs::Mapentry = Pattern[/^[a-z]+:\/([^\/\0]+(\/)?)+$|^-hosts$/]
+type Autofs::Mapentry = Pattern[/\A([a-z]+(,[a-z]+)?:\S+|-hosts)\z/]


### PR DESCRIPTION

#### Pull Request (PR) description
The Autofs::Mapentry type rejected some map designations that Autofs itself
permits.  The type is updated to accept all valid designations that
aren't plain absolute paths.

Inasmuch as the accepted designations vary with the specified map type,
and this data type does not make distinctions based on map type (and never
did), it now accepts some map designations that Autofs will reject.
Specifically, for 'file', 'directory', and 'program' map types, Autofs expects
the map name to be an absolute path, and the Autofs::Mapentry data
type no longer enforces this.  This is a direct consequence of the type
now intentionally allowing map names for _other_ map types that do
not have the form of absolute paths.

#### This Pull Request (PR) fixes the following issues
Fixes #115
