### PR TITLE
Minimalistic revisions for fixing distributed map file and master map management

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,150 @@ class { 'autofs':
 }
 ```
 
+### Master Map
+
+The module provides two compatible, built-in mechanisms for managing the
+content of the master map: by setting the `mounts` parameter of the `autofs`
+class, and by declaration of `autofs::mount` resources.  Using these is not
+obligatory -- one could instead use a `File` resource, for instance, but
+using the built-in mechanisms automatically provides for the autofs service
+to be notified of any changes to the master map.
+
+Note well, however, that managing the master map via this module's built-in
+mechanisms is generally an all-or-nothing affair.  If any autofs mount points
+are managed present in the master map via either of those mechanisms, then
+*only* such mount points will appear in the master map.
+
+##### example
+
+The declaration
+
+```puppet
+autofs::mount { 'home':
+  mount       => '/home',
+  mapfile     => '/etc/auto.home',
+  options     => '--timeout=120'
+}
+```
+
+, or the equivalent element of the value of class parameter
+`$autofs::mounts`, will result in the following entry in the master
+map"
+
+```
+/home /etc/auto.home --timeout=120
+```
+
+The target map file, `/etc/auto.home`, is not affected by this.
+
+Alternatively, this can be expressed directly in the declaration of
+class `autofs`:
+
+```puppet
+class { 'autofs':
+  mounts => {
+    'home' => {
+      'mount'   => '/home',
+      'mapfile' => '/etc/auto.home',
+      'options' => '--timeout=120'
+    }
+  }
+}
+```
+
+or in YAML form in external Hiera data:
+
+```yaml
+lookup_options:
+  autofs::mounts:
+    merge: hash
+autofs::mounts:
+  home:
+    mount: '/home'
+    mapfile: '/etc/auto.home'
+    options: '--timeout=120'
+```
+
+For more information about merge behavior see the doc for:
+
+* [Lookup docs](https://docs.puppet.com/puppet/4.7/lookup_quick.html#puppet-lookup:-quick-reference-for-hiera-users) 
+* [Hiera 5 docs](https://docs.puppet.com/puppet/5.1/hiera_merging.html) if using Puppet >= 4.9
+
+
+#### Direct Map `/-` arugment
+
+The autofs module supports Autofs direct maps naturally.  For a direct map, simply specify the `mount` parameter as `/-`,
+just as is used for the purpose in the `auto.master` file.  When this option is exercised, Autofs requires the keys in the
+corresponding map file to be absolute paths of mountpoint directories; this module does *not* validate that constraint.
+
+##### Examples:
+
+Define:
+``` puppet
+autofs::mount { 'foo':
+  mount       => '/-',
+  mapfile     => '/etc/auto.foo',
+  mapcontents => ['/foo -o options /bar'],
+  options     => '--timeout=120',
+  order       => 01
+}
+```
+
+Hiera:
+``` yaml
+autofs::mounts:
+  foo:
+    mount: '/-'
+    mapfile: '/etc/auto.foo'
+    mapcontents:
+      - '/foo -o options /bar'
+    options: '--timeout=120'
+    order: 01
+```
+
+#### Autofs `+dir:` options
+
+The autofs module supports the use of Autofs's `+dir:` option (Autofs 5.0.5 or later) in the `auto.master` file to
+incorporate the contents of all files from a specified directory into the master map's own logical content.  When a
+`mount`'s `use_dir` parameter is `true` (default is `false`), the corresponding `auto.master` content is created as a
+separate file in the appropriate directory instead of being written directly into `auto.master`.  `auto.master` is,
+however, ensured to contain an appropriate `+dir:` entry designating the chosen fragment directory.
+
+##### Usage
+
+Define:
+```puppet
+autofs::mount { 'home':
+  mount       => '/home',
+  mapfile     => '/etc/auto.home',
+  mapcontents => ['* -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl server.example.com:/path/to/home/shares'],
+  options     => '--timeout=120',
+  order       => 01,
+  use_dir     => true
+}
+```
+
+Hiera:
+```yaml
+autofs::mounts:
+  home:
+    mount: '/home'
+    mapfile: '/etc/auto.home'
+    mapcontents:
+      - '* -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl server.example.com:/path/to/home/shares'
+    options: '--timeout=120'
+    order: 01
+    use_dir: true
+```
+
 ### Map Files
 
-This module provides several ways to manage Autofs map files.  In the first place, there is a defined type serving this purpose:
+This module provides several ways to manage Autofs map files, but it all starts with the
+`autofs::mount` resource discussed above.  By default, such resources or their
+corresponding external-data representations set up management for the designated map
+file, as well, and they may provide some or all of the map file content. For example, this
+Puppet code
+
 ```puppet
 autofs::mount { 'home':
   mount       => '/home',
@@ -78,15 +219,12 @@ autofs::mount { 'home':
   order       => 01
 }
 ```
-This example will generate content in both the auto.master file and the auto.home map
-file:
 
-##### auto.master
-```
-/home /etc/auto.home --timeout=120
-```
+not only manages an entry in the master map, as described above, but also ensures that the
+designated map file exists and contains the mapping designated via the `mapcontents`
+parameter:
 
-##### auto.home
+#### /etc/auto.home
 ```
 * -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl server.example.com:/path/to/home/shares
 ```
@@ -125,72 +263,6 @@ For more information about merge behavior see the doc for:
 * [Lookup docs](https://docs.puppet.com/puppet/4.7/lookup_quick.html#puppet-lookup:-quick-reference-for-hiera-users) 
 * [Hiera 5 docs](https://docs.puppet.com/puppet/5.1/hiera_merging.html) if using Puppet >= 4.9
 
-##### Direct Map `/-` arugment
-
-The autofs module supports Autofs direct maps naturally.  For a direct map, simply specify the `mount` parameter as `/-`,
-just as is used for the purpose in the `auto.master` file.  When this option is exercised, Autofs requires the keys in the
-corresponding map file to be absolute paths of mountpoint directories; this module does *not* validate that constraint.
-
-###### Examples:
-
-Define:
-``` puppet
-autofs::mount { 'foo':
-  mount       => '/-',
-  mapfile     => '/etc/auto.foo',
-  mapcontents => ['/foo -o options /bar'],
-  options     => '--timeout=120',
-  order       => 01
-}
-```
-
-Hiera:
-``` yaml
-autofs::mounts:
-  foo:
-    mount: '/-'
-    mapfile: '/etc/auto.foo'
-    mapcontents:
-      - '/foo -o options /bar'
-    options: '--timeout=120'
-    order: 01
-```
-
-##### Autofs `+dir:` options
-
-The autofs module supports the use of Autofs's `+dir:` option (Autofs 5.0.5 or later) in the `auto.master` file to
-incorporate the contents of all files from a specified directory into the master map's own logical content.  When a
-`mount`'s `use_dir` parameter is `true` (default is `false`), the corresponding `auto.master` content is created as a
-separate file in the appropriate directory instead of being written directly into `auto.master`.  `auto.master` is,
-however, ensured to contain an appropriate `+dir:` entry designating the chosen fragment directory.
-
-###### Usage
-
-Define:
-```puppet
-autofs::mount { 'home':
-  mount       => '/home',
-  mapfile     => '/etc/auto.home',
-  mapcontents => ['* -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl server.example.com:/path/to/home/shares'],
-  options     => '--timeout=120',
-  order       => 01,
-  use_dir     => true
-}
-```
-
-Hiera:
-```yaml
-autofs::mounts:
-  home:
-    mount: '/home'
-    mapfile: '/etc/auto.home'
-    mapcontents:
-      - '* -user,rw,soft,intr,rsize=32768,wsize=32768,tcp,nfsvers=3,noacl server.example.com:/path/to/home/shares'
-    options: '--timeout=120'
-    order: 01
-    use_dir: true
-```
-
 #### Map Entries
 As an alternative to adding map entries via the `mapcontents` parameter of an `autofs::mount`, there is an `autofs::map`
 type that serves the purpose as well.
@@ -213,7 +285,7 @@ autofs::maps:
     mapcontent: 'data -user,rw server.example.com:/path/to/data'
 ```
 
-It is assumed in this case that the map file itself is managed separately, such as via an `autofs::mount` resource.
+It is assumed in this case that the map file itself is managed separately, via an `autofs::mount` resource.
 
 ```puppet
 autofs::mount{'auto.data':
@@ -221,6 +293,10 @@ autofs::mount{'auto.data':
   mount   => '/big',
 }
 ```
+
+Multiple `autofs::map` resources may target the same map file.  The contents
+they specify will be combined, together with any contents specified by the
+overall `autofs::mount`.
 
 ##### Removing Entries
 
@@ -261,7 +337,131 @@ autofs::maps:
       - 'dataB -o rw /mnt/dataB'
 ```
 
-**NOTE: Do NOT set `ensure => 'absent'` unless your intent is to remove the entire `mapfile`!**
+Alternatively, to suppress all map file content declared via an `autofs::map`
+resource, one can `ensure` the whole `autofs::map` as being `absent`:
+
+```puppet
+autofs::map {'data':
+  ensure      => 'absent',
+  mapfile     => '/etc/auto.data',
+  mapcontents => [ 'dataA -o rw /mnt/dataA', 'dataB -o rw /mnt/dataB' ],
+}
+```
+
+```yaml
+autofs::maps:
+  data:
+    ensure: absent
+    mapfile: '/etc/auto.data'
+    mapcontents:
+      - 'dataA -o rw /mnt/dataA'
+      - 'dataB -o rw /mnt/dataB'
+```
+
+**NOTE:** this behavior of the `ensure` parameter is a change from that in
+the original implementation of `autofs::map`, which would cause the whole
+target map file to be removed (when it worked).  Before relying on this
+documentation, be sure you are using a version of the module to which
+this documentation applies.
+
+#### Removing whole map files
+
+By default, `autofs::mount` resources manage map files at least by ensuring
+that they are present on the system and have appropriate ownership and mode.
+It is straightforward, however, to instead manage them to be absent.  This
+is accomplished via the `ensure` parameter:
+
+```puppet
+autofs::mount { 'unwanted':
+  mount   => '/mnt/oops',
+  mapfile => '/etc/auto.unwanted',
+  ensure  => 'absent'
+}
+```
+
+external-data variation:
+
+```yaml
+autofs::mounts:
+  unwanted:
+    mount: '/mnt/oops'
+    mapfile: '/etc/auto.unwanted'
+    ensure: 'absent'
+```
+
+The example will ensure not only that the map file is absent from the
+system, but also the corresponding entry is absent from the master map.  The
+effect can be narrowed to just one or the other via the general mechanism
+for adjusting the scope of `autofs::mount`, discussed next. 
+
+### Controlling `autofs::mount` scope
+
+We have seen that by default, autofs::mount` resources both manage an
+entry in the master map and play a central role in managing the associated
+map file.  It may, however, be desirable for such resources to manage just
+one or the other.  For this purpose, the type provides boolean parameters
+`$mapfile_manage` and `$master_manage` that control whether an instance
+in fact does manage a mapfile or an entry in the master map, respectively.
+Both default to `true`.
+
+In most cases, these parameters can be assigned values independently of
+each other and of the other parameters, but if an `autofs::mount` resource
+specifies a mapfile other than via an absolute path, such as by designating
+the built-in "-hosts" map, then that resource's `$mapfile_manage` *must* be
+specified as `false`.  Instances with `$mapfile_manage` and `$master_manage`
+both `false` are accepted, but will elicit a warning.
+
+#### Managing _only_ a master map entry
+
+For example, one might use this Puppet code to manage a mount point for
+the `-hosts` map:
+
+```puppet
+autofs::mount { 'hosts':
+  mount          => '/net',
+  mapfile        => '-hosts',
+  mapfile_manage => false,
+}
+```
+
+The equivalent external data is
+
+```yaml
+autofs::mounts:
+  hosts:
+    mount: '/net'
+    mapfile: '-hosts'
+    mapfile_manage: false
+```
+
+#### Managing _only_ a map file
+
+On the other hand, suppose the target OS's autofs package enables a
+drop-in directory automatically.  One can leverage that to set up autofs
+mount points without modifying the master map (which indeed is one of the
+purposes for the drop-in directory feature):
+
+```puppet
+autofs::mount { 'data':
+  mount         => '/mnt/data',
+  mapfile       => '/etc/auto.data',
+  mapcontents   => ['dataA -ro remote.com:/exports/dataA']
+  master_manage => false,
+}
+
+file { '/etc/auto.master.d/data.autofs':
+  ensure  => 'file',
+  user    => 'root',
+  group   => 'root',
+  mode    => '0644',
+  content => '/mnt/data /etc/auto.data'
+}
+```
+
+This module makes no provision for managing the drop-in `data.autofs` file
+in this case, neither via a declarable resource type nor via external data.
+It is treated as part of the master map, and therefore is managed if and
+only if the master map is managed.
 
 
 ## Reference
@@ -288,6 +488,23 @@ Data type: Hash
 A hash of options that describe contents of the master map, and possibly of individual map files.  Each entry is equivalent
 to the title and a hash of the parameters of one `autofs::mount` resource.
 
+#### `maps`
+
+Optional.
+
+Data type: Hash
+
+A hash of options that describe filesystem mappings in various mapfiles under management.
+Each entry is equivalent to the title and a hash of parameters of one `autofs::map` resource.
+
+#### `package_name`
+
+Data type: String or Array[String]
+
+The name of the Autofs package(s).  System-appropriate values for a variety
+of target environments are included with the module, so this parameter
+does not usually need to be specified explicitly.
+
 #### `package_ensure`
 
 Data type: String
@@ -296,6 +513,24 @@ Determines the required state of the autofs package. Can be set to: `installed`,
 version string.
 
 Default: 'installed'
+
+#### `package_source`
+
+Optional.
+
+Data type: String
+
+Specifies the name of the package source, for those target systems that
+need it (AIX).  The system-dependent default value is normally appropriate.
+
+#### `service_name`
+
+Data type: String
+
+The name of the Autofs service, as appropriate for use with the target
+environment's tools.  System-appropriate values for a variety of
+target environments are included with the module, so this parameter
+does not usually need to be specified explicitly.
 
 #### `service_ensure`
 
@@ -313,6 +548,47 @@ Determines whether the autofs service should start at system boot.
 
 Default: `true`
 
+#### `reload_command`
+
+Optional.
+
+Data type: String
+
+If specified, a command to execute in the target environment to reload
+Autofs configuration without restarting the service.  This module provides
+system-dependent default values for several systems that provide such a
+feature, so it is usually unnecessary to specify this parameter explicitly.
+
+#### `auto_master_map`
+
+Data type: String
+
+The absolute path to the Autofs master map.  The standard paths used on
+a variety of supported environments are included with the module, so this
+parameter does not usually need to be specified explicitly.
+
+#### `map_file_owner`
+
+Data type: String
+
+The system user who should own the master map and any managed map files.
+May be expressed either as a name or as a uid (in string form).  The
+module defaults to 'root' for most environments and provides alternative
+defaults for supported target environments that ordinarily differ in this
+regard, so it is rarely necessary to specify this parameter explicitly
+unless a non-standard value is desired.
+
+#### `map_file_group`
+
+Data type: String
+
+The system group to which the master map and any managed map files should
+be assigned.  May be expressed either as a name or as a gid (in string
+form).  The module defaults to 'root' for most environments and provides
+alternative defaults for supported target environments that ordinarily
+differ in this regard, so it is rarely necessary to specify this
+parameter explicitly unless a non-standard value is desired.
+
 ### Defines
 
 #### Public Defines
@@ -327,10 +603,12 @@ Default: `true`
 
 Data type: String
 
-The desired state of the mount definition in the master map.  If set to `absent`, the resulting master map will not
-contain a mountpoint definition corresponding to this resource, nor will it cause a map file or any map file content
-to be managed (but such content could still be created and managed via `autofs::map` resources or *other*
-`autofs::mount` resources). Defaults to `present`.
+The desired state of the mountpoint definition in the master map and / or
+map file managed by this resource.  If set to `absent` and `$master_manage`
+is `true` (its default), the master map will not contain a mountpoint
+definition corresponding to this resource.  If set to `absent` and
+`$mapfile_manage` is `true` (its default), the map file designated by
+this resource will be ensured absent.  Defaults to `present`.
 
 #### `mount`
 
@@ -352,8 +630,13 @@ here, but most commonly this is either an absolute path to a map file or the spe
 If its value is anything other than a plain absolute path, then the `mapfile_manage` parameter must take the
 value `false`, and the specified mapfile must be managed separately.
 
-This parameter corresponds to content in the master map.  If `mapfile_manage` is `true` (its default), then
-the presence of this parameter also causes the corresponding map file to be created and managed.
+This parameter is optional only for backwards compatibility.  It _should_ always be provided.  If omitted,
+the options will be interpreted as the map file, instead, and if both are omitted then any resulting
+master map entry will be malformed.
+
+If `master_manage` is `true` (its default) then this parameter corresponds to content in the master map.
+If `mapfile_manage` is `true` (its default) then the presence of this parameter also causes the
+corresponding map file to be managed.
 
 #### `mapfile_manage`
 
@@ -379,8 +662,8 @@ Optional.
 
 Data type: String
 
-This Mapping describes the auto.master options to use (if any)
-when mounting the automounts.
+This mapping describes the autofs and mount options to associate with the
+master map entry, if any, managed by this resource.
 
 Default: ''
 
@@ -388,25 +671,46 @@ Default: ''
 
 Data type: Integer
 
-This Mapping describes where in the auto.master file the entry will
-be placed. Order CANNOT be duplicated.
+When this resource manages an entry in the master map, this parameter
+designates its position relative to other managed entries.  Autofs is
+sensitive to master map order only insomuchas multiple entries can be
+matched to the same request, so often it is unnecessary to manage
+entry order.
 
-Default: `undef`
+Default: 10
 
 #### `master`
 
 Data type: Stdlib::Absolutepath
 
-This Parameter sets the path to the auto.master file.
+This parameter specifies the path to the Autofs master map, if any, in
+which this resource will manage an entry.  The provided system-dependant
+default is usually appropriate, so it is rarely necessary to specify
+this parameter explicitly.
 
-Default: '/etc/auto.master'
+Default: (system-dependent)
+
+#### `master_manage`
+
+Data type: Boolean
+
+Indicates whether this resource should manage the master map to include
+(or omit) the mount point declaration described by this resource.  In the
+event that the catalog contains any `autofs::mount` resources that are
+ensured present, it is advisable that _all_ wanted entries that should be
+present in the master map be managed via `autofs::mount` resources having
+`master_manage` set to `true.
+
+Default: `true`
 
 #### `map_dir`
 
 Data type: Stdlib::Absolutepath
 
-This Parameter sets the path to the Autofs configuration directory
-for map files. Applies only to autofs 5.0.5 or later. 
+This parameter specifies the path to the Autofs master map drop-in directory
+in which this mount's definition should reside.  This may differ from mount
+to mount. Applies only to autofs 5.0.5 or later, and only when the `use_dir`
+and `master_manage` parameters are both set to `true`.
 
 Default: '/etc/auto.master.d'
 
@@ -414,7 +718,9 @@ Default: '/etc/auto.master.d'
 
 Data type: Boolean
 
-This Parameter tells the module if it is going to use $map_dir.
+This parameter specifies whether to manage this mount point via its own file
+in a drop-in directory, as opposed to recording it directly in the master
+map.  Relevant only for autofs 5.0.5 or later.
 
 Default: `false`
 
@@ -432,7 +738,14 @@ Default: `true`
 
 Data type: Boolean
 
-Whether the mapfile should be an executable shell script.
+Whether the mapfile, if any, managed by this resource should be have
+an executable mode.
+
+This option is probably not what you want.  For a master map entry refering
+to an executable map, you should declare the `mapfile` parameter with a
+`program:` prefix, which requires `mapfile_manage` to be `false`.  You could
+then manage the specified map program via some other resource, such as a
+`File`.  This parameter is irrelevant to that scenario.
 
 Default: `false`
 
@@ -440,7 +753,9 @@ Default: `false`
 
 Data type: Boolean
 
-Whether to replace the mapfile if it already exists.
+When this resource is managing a map file and that file already exists, this
+parameter specifies whether its contents should be managed according to this
+resource and any `autofs::map` resources targeting the same file.
 
 Default: `true`
 
@@ -450,8 +765,10 @@ Default: `true`
 
 Data type: String
 
-Ensures the state of the `mapfile`. Setting to `absent` **WILL REMOVE THE MAPFILE**. If you just
-to remove an entry in the `mapfile`, remove the `mapcontents` string or array element you want to remove.
+Whether the mapfile contents should be present in the target map file.
+Unlike in some previous versions of this module, the overall presence
+or absence of the `mapfile` is unaffected.  Specifying 'absent' has
+substantially the same effect as omitting the resource altogether.
 
 Default: 'present'
 
@@ -459,7 +776,7 @@ Default: 'present'
 
 Data type: Stdlib::Absolutepath
 
-The autofs map file managed to which this resource provides contents. e.g '/etc/auto.data'.
+The autofs map file for which this resource specifies contents. e.g '/etc/auto.data'.
 
 #### `mapcontents`
 
@@ -472,9 +789,20 @@ are three whitespace-delimited fields: an identifying "key", which automount com
 this map to form the mount path; the mount options as a comma-delimited string; and the remote or local filesystem
 to be mounted.
 
-Used in mapfile generation. Example: 'data -rw nfs.example.org:/data/big'
+Example: 'data -rw nfs.example.org:/data/big'
 
 Default: []
+
+#### `order`
+
+Data type: Integer
+
+The relative order of the map file contents managed by this resource, with
+respect to that managed by other resources.  Order matters only in the event
+that the same key appears multiple times, so this parameter rarely needs to
+be specified.
+
+Default: 50
 
 
 Limitations
@@ -485,7 +813,8 @@ Directly calling the `autofs::package` and `autofs::service` classes is disabled
 These are now private classes.
 
 #### Puppet platforms
-Compatible with Puppet 4 only. Puppet 4.6.0 will provide best results.
+Compatible with Puppet 4 or higher only. Puppet 4.6.0 or later, including
+Puppet 5, will provide best results.
 
 #### Operating Systems
 

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -1,7 +1,11 @@
 # Define: autofs::map
 #
-# Defined type to generate autofs map entry
-# configuration files.
+# Defined type to manage mappings in Autofs map files that are managed
+# via autofs::mount instances.  It is an error to declare an autofs::mount
+# with a $mapfile for which there is not also an autofs::mount declared,
+# whether via manifest code or via equivalent data.  Multiple autofs::map
+# resources can contribute content to the same map file, and such content
+# is combined with any specified via the corresponding autofs::mount.
 #
 # @see https://voxpupuli.org/puppet-autofs Home
 # @see https://voxpupuli.org/puppet-autofs/puppet_classes/autofs.html puppet_classes::autofs
@@ -11,61 +15,77 @@
 # @author Vox Pupuli <voxpupuli@groups.io>
 # @author David Hollinger III <david.hollinger@moduletux.com>
 #
-# @example Using the autofs::map defined type to setup automount for nfs data directory.
-#   autofs::map { 'data':
-#     mapcontents => 'mydata -user,rw,soft,intr,rsize=32768,wsize=32768  nfs.example.org:/path/to/some/data',
-#     mapfile => '/etc/auto.data',
-#     order   => '01',
+# @example Using autofs::map together with autofs::mount to set up
+#   automounting for several NFS filesystems
+#   @autofs::mount { 'example':
+#     mount   => '/mnt/example',
+#     mapfile => '/etc/auto.example',
+#   }
+#   @autofs::map { 'fs1':
+#     mapfile     => '/etc/auto.example',
+#     mapcontents => [
+#       'fs1 -rw nfs.example.org:/path/to/fs1',
+#       'fs2 -ro nfs.example.org:/path/to/fs2'
+#     ],
+#   }
+#   @autofs::map { 'fs3':
+#     mapfile     => '/etc/auto.example',
+#     mapcontents => [
+#       'fs3 -rw other.example.org:/path/to/fs3'
+#     ],
 #   }
 #
-# @param ensure Whether to create the mapfile or not.
-# @param mapcontents The mount point options and parameters, 
-#   Example: '* -user,rw,soft nfs.example.org:/path/to'
-# @param mapfile Name of the "auto." configuration file that will be generated.
-# @param template Template to use to generate the mapfile.
-# @param mapmode UNIX permissions to be added to the file.
-# @param replace Whether or not to replace an existing mapfile of the same filename/path.
-# @param order Order in which entries will appear in the autofs map file.
+# @param ensure Whether the contents of the map should be present in the
+#   target map file.  Does not influence the presence or absence of the map
+#   file itself.  Affirmatively ensuring 'absent' has the same effect as
+#   omitting the resource declaration altogether (default: 'present').
+# @param mapfile Path to the map file for which this resource provides contents
+# @param mapcontents A filesystem mapping or an array of them, each in Autofs
+#   map file format.  In principle, this should instead be shell script code
+#   if the target mapfile is an executable map, but it is not recommended or
+#   supported to use autofs::map resources for such map files.
+#   Example: ['* -rw nfs.example.org:/path/to']
+# @param order The order in which the contents given by this resource
+#   will appear in the designated map file, relative to contents specified
+#   by other 'autofs::map' resources, by the corresponding 'autofs::mount'
+#   resource (50), or by the corresponding (external-)data representations of
+#   these.  The seqence of map entries matters only when there are multiple
+#   mappings matching the same key. (default: 50)
+# @param mapmode DEPRECATED: has no effect, and may be omitted
+# @param replace DEPRECATED: has no effect, and may be omitted
+# @param template DEPRECATED: has no effect, and may be omitted
 #
 define autofs::map (
   Enum['present', 'absent'] $ensure                                 = 'present',
   Stdlib::Absolutepath $mapfile                                     = $title,
-  Enum['autofs/auto.map.erb', 'autofs/auto.map.exec.erb'] $template = 'autofs/auto.map.erb',
-  String $mapmode                                                   = '0644',
-  Boolean $replace                                                  = true,
-  Integer $order                                                    = 1,
-  Variant[Array, String] $mapcontents                               = [],
+  Optional[String] $template                                        = undef,     # ignored
+  Optional[String] $mapmode                                         = undef,     # ignored
+  Optional[Boolean] $replace                                        = undef,     # ignored
+  Integer $order                                                    = 50,
+  Variant[Array[String], String] $mapcontents                       = [],
 ) {
   include '::autofs'
 
-  unless $::autofs::package_ensure == 'absent' {
-    if $autofs::reload_command {
-      Concat {
-        before => Service[$autofs::service_name],
-        notify => Exec['automount-reload'],
-      }
-    } else {
-      Concat {
-        notify => Service[$autofs::service_name],
-      }
-    }
+  if $template =~ NotUndef {
+    deprecation('autofs::map::template',
+        'Parameter $template of autofs::map is deprecated and has no effect.  Do not use it.')
   }
 
-  ensure_resource(concat,$mapfile,{
-    ensure  => $ensure,
-    owner   => $autofs::map_file_owner,
-    group   => $autofs::map_file_group,
-    mode    => $mapmode,
-    replace => $replace,
-    require => Class['autofs::package'],
-  })
+  if $mapmode =~ NotUndef {
+    deprecation('autofs::map::mapmode',
+        'Parameter $mapmode of autofs::map is deprecated and has no effect.  Use $autofs::mount::execute instead.')
+  }
+
+  if $replace =~ NotUndef {
+    deprecation('autofs::map::replace',
+        'Parameter $replace of autofs::map is deprecated and has no effect.  Use $autofs::mount::replace instead.')
+  }
 
   unless $ensure == 'absent' {
     concat::fragment { "${mapfile}_${name}_entries":
       target  => $mapfile,
-      content => template($template),
+      content => template('autofs/auto.map.erb'),
       order   => $order,
     }
   }
-
 }

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -131,7 +131,7 @@ define autofs::mount (
   }
 
   if (length($mapcontents) > 0) and !$mapfile_manage {
-    warn("Map file contents specified for autofs::mount[$title], but no map file is being managed")
+    warn("Map file contents specified for autofs::mount[${title}], but no map file is being managed")
   }
 
   if $mapfile {
@@ -220,11 +220,12 @@ define autofs::mount (
   }
 
   if $mapfile and $mapfile_manage {
+    $mapmode = $execute ? { true => '0755', default => '0644' }
     concat { $mapfile:
       ensure  => $ensure,
       owner   => $autofs::map_file_owner,
       group   => $autofs::map_file_group,
-      mode    => $execute ? { true => '0755', default => '0644' },
+      mode    => $mapmode,
       replace => $replace,
       force   => true,
       warn    => template('autofs/map.banner.erb'),

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -1,7 +1,13 @@
 # Define: autofs::mount
 #
-# Defined type to generate autofs mount point
-# configuration files.
+# Defined type to manage mountpoint mappings in the Autofs master map,
+# and / or to manage the corresponding map files.
+# Supplemental mapfile content can be provided by autofs::map resources.
+#
+# Warning: if at least one autofs::mount is declared with ensure => present
+# and master_manage => true (their defaults) then the entire master map is
+# managed.  In that case, only mount points declared present by autofs::mount
+# resources with master_manage => true will be retained in the master map.
 #
 # @see https://voxpupuli.org/puppet-autofs Home
 # @see https://voxpupuli.org/puppet-autofs/puppet_classes/autofs.html puppet_classes::autofs
@@ -11,7 +17,7 @@
 # @author Vox Pupuli <voxpupuli@groups.io>
 # @author David Hollinger III <david.hollinger@moduletux.com>
 #
-# @example Using the autofs::mount defined type to setup automount for user home directories.
+# @example Using the autofs::mount defined type to set up automount for user home directories.
 #   autofs::mount { 'home':
 #     mount          => '/home',
 #     mapfile        => '/etc/auto.home',
@@ -20,7 +26,7 @@
 #     order          => 01
 #   }
 #
-# @example Using autofs::mount defined type to create an enty for an existing auto.smb file.
+# @example Using the autofs::mount defined type to create an enty for an existing auto.smb file.
 #   autofs::mount { 'smb':
 #     mount          => '/smb',
 #     mapfile        => 'program:/etc/auto.smb',
@@ -28,43 +34,82 @@
 #     options        => '--timeout=120',
 #   }
 #
-# @example Remove an autofs::mount
+# @example Remove an entry from the master map
 #   autofs::mount { '/smb':
 #     ensure  => 'absent',
 #     mapfile => 'program:/etc/auto.smb',
 #   }
 #
-# @param ensure Whether the mount should exist or not.
-# @param mount Location where you will mount the remote NFS Share.
-# @param mapfile Name of the "auto." configuration file that will be generated.
-#   can be a filepath or maptype and path.
-# @param mapcontents The mount point options and parameters.
-#   Example: '* -user,rw,soft server.example.com:/path/to/home/shares'
-# @param master Full path, including filename, to the autofs master file.
+# @example Manage a map file, but not an entry in the master map
+#   autofs::mount { '/mnt/example':
+#     mapfile       => '/etc/auto.example',
+#     master_manage => false,
+#     mapcontents   => [
+#       'fs1 -rw /server.example.com:/path/to/example/share'
+#     ],
+#   }
+#
+# @param ensure When managing an entry in the master map, whether that entry
+#   entry should be present, and when managing a corresponding map file,
+#   whether that file should be present (default: 'present').
+# @param execute If true, the $mapfile will be an executable script;
+#   otherwise it will be a normal file, which Autofs will expect to be in
+#   its standard map file format.  Meaningful only when $mapfile_manage is
+#   true, and has implications on the appropriate value of `mapcontents`.
+#   (default: false).
+# @param mapcontents A filesystem mapping or an array of them, each in Autofs
+#   map file format (non-executable maps); alternatively, shell script code
+#   implementing the map (executable maps only).
+#   Example: ['* -user,rw,soft nfs.example.org:/path/to']
+#   (default: [])
 # @param map_dir Full path, including directory name, to the autofs master
-#   configuration directory. Only required if use_dir is set to true.
-# @param use_dir If true, autofs will look for master configuration in the map_dir
-#   path using filenames ending in the ".autofs" extension.
-# @param options Options for the autofs mount point within in the auto.master.
-# @param order Order in which entries will appear in the autofs master file.
-# @param direct Boolean to allow for indirect map. Defaults to true to be
-#   backwards compatible.
-# @param execute If true, it will make the $mapfile an executable script,
-#   otherwise the file is a standard "auto." configuration file.
-# @param mapfile_manage Boolean will manaage the map file specifed in mapfile
-#   paramter.
-# @param replace Set to false if you only want to place the file if it is missing.
+#   map drop-in directory. Required only when $use_dir is set to true.
+#   (default: '/etc/auto.master.d')
+# @param mapfile Name of the Autofs map file that will associate subdirectories
+#   of the mountpoint directory with specific filesystems (often, but not
+#   always, remote ones) and the appropriate mount options.  Alternatively, can
+#   name the built-in '-hosts' map.
+# @param mapfile_manage A boolean indicating whether the file designated by
+#   the $mapfile parameter should be managed, too, as opposed to managing
+#   only an entry in the master map (default: true).
+# @param master Full path, including filename, to the autofs master map.
+#   (default: <machine-dependent>)
+# @param master_manage Whether to manage (an entry in) the master map as
+#   described by this resource.
+# @param mount The Autofs mount point directory, or '/-' for a direct map.
+#   For indirect maps, Autofs will mount filesystems in automatically-created
+#   subdirectories of this directory (default: the title of this resource).
+# @param options Options to be specified for this mount point in the Autofs
+#   master map (default: '').
+# @param order The order of this mount point mapping in the master map,
+#   relative to other mount point mappings.  Meaningful only when $use_dir
+#   is false.  (default: 10)
+# @param replace Whether the existing map file should be managed if it already
+#   exists (the entry in the master map is managed regardless).  Set to false
+#   if you only want to avoid modifying the file when it already exists
+#   (default: true).
+# @param use_dir If true, autofs will manage details of this mount point via
+#   a file in the drop-in directory specified by $map_dir, instead of by
+#   writing them directly into the master map.  The master map will still be
+#   ensured to contain an appropriate '+dir:' mapping for the directory,
+#   but that can support multiple mount point mappings, and it may be present
+#   by default.  (default: false)
+# @param direct Deprecated.  Retained for backwards compatibility, but has no
+#   effect.  Opt for a direct map via your choice of $mount parameter --
+#   the value '/-' (of $mount) is meaningful to Autofs for that purpose.
+#   (default: true)
 #
 define autofs::mount (
   Enum['present', 'absent'] $ensure       = 'present',
   Stdlib::Absolutepath $mount             = $title,
-  Integer $order                          = 1,
+  Integer $order                          = 10,
   Optional[Variant[Stdlib::Absolutepath,Autofs::Mapentry]] $mapfile = undef,
   Optional[String] $options               = '',
   Stdlib::Absolutepath $master            = $autofs::auto_master_map,
+  Boolean $master_manage                  = true,
   Stdlib::Absolutepath $map_dir           = '/etc/auto.master.d',
   Boolean $use_dir                        = false,
-  Boolean $direct                         = true,
+  Optional[Boolean] $direct               = undef,  # deprecated
   Boolean $execute                        = false,
   Boolean $mapfile_manage                 = true,
   Variant[Array, String] $mapcontents     = [],
@@ -76,19 +121,19 @@ define autofs::mount (
     fail("Parameter 'mapfile_manage' must be false for complicated 'mapfile' ${mapfile}")
   }
 
+  if $execute =~ NotUndef {
+    deprecation('autofs::mount::direct',
+        'Resource parameter $::autofs::mount::direct is deprecated and has no effect')
+  }
+
+  if !($master_manage or $mapfile_manage) {
+    warn("Autofs::Mount[${title}] does not manage anything")
+  }
+
   if $mapfile {
     $contents = "${mount} ${mapfile} ${options}\n"
   } else {
     $contents = "${mount} ${options}\n"
-  }
-
-  if $execute {
-    $mapperms = '0755'
-    $maptempl = 'autofs/auto.map.exec.erb'
-  }
-  else {
-    $mapperms = '0644'
-    $maptempl = 'autofs/auto.map.erb'
   }
 
   unless $::autofs::package_ensure == 'absent' {
@@ -97,74 +142,95 @@ define autofs::mount (
         before => Service[$autofs::service_name],
         notify => Exec['automount-reload'],
       }
+      File_line {
+        before => Service[$autofs::service_name],
+        notify => Exec['automount-reload'],
+      }
     } else {
       Concat {
+        notify => Service[$autofs::service_name],
+      }
+      File_line {
         notify => Service[$autofs::service_name],
       }
     }
   }
 
-  if !defined(Concat[$master]) {
-    concat { $master:
-      owner          => $autofs::map_file_owner,
-      group          => $autofs::map_file_group,
-      mode           => '0644',
-      ensure_newline => true,
+  if $master_manage {
+    if !defined(Concat[$master]) {
+      concat { $master:
+        owner          => $autofs::map_file_owner,
+        group          => $autofs::map_file_group,
+        mode           => '0644',
+        ensure_newline => true,
+      }
     }
-  }
 
-  if $use_dir == false {
-    if $ensure == 'present' {
-      concat::fragment { "autofs::fragment preamble ${mount} ${mapfile}":
-        target  => $master,
-        content => $contents,
-        order   => $order,
+    if $use_dir == false {
+      if $ensure == 'present' {
+        concat::fragment { "autofs::fragment preamble ${mount} ${mapfile}":
+          target  => $master,
+          content => $contents,
+          order   => $order,
+        }
+      } else {
+        # If there is at least one autofs::mount resource with
+        # ensure => 'present' then the following is superfluous -- the master
+        # map will be rebuilt without any contribution from this resource.  But
+        # in case there isn't any such autofs::mount, we need to affirmatively
+        # remove this resource's corresponding line, if any, from the master map.
+        file_line { "remove_contents_${mount}_${mapfile}":
+          ensure            => 'absent',
+          path              => $master,
+          match             => "^${contents}",
+          match_for_absence => true,
+        }
       }
     } else {
-      file_line { "remove_contents_${mount}_${mapfile}":
-        ensure            => absent,
-        path              => $master,
-        match             => "^${contents}",
-        match_for_absence => true,
-        notify            => Service['autofs'],
-      }
-    }
-  } else {
-    ensure_resource('file', $map_dir, {
-      'ensure'  => directory,
-      'owner'   => $autofs::map_file_owner,
-      'group'   => $autofs::map_file_group,
-      'mode'    => '0755',
-      'require' => Class['autofs::package'],
-    })
+      ensure_resource('file', $map_dir, {
+        'ensure'  => directory,
+        'owner'   => $autofs::map_file_owner,
+        'group'   => $autofs::map_file_group,
+        'mode'    => '0755',
+        'require' => Class['autofs::package'],
+      })
 
-    if !defined(Concat::Fragment['autofs::fragment preamble map directory']) and $ensure == 'present' {
-      concat::fragment { 'autofs::fragment preamble map directory':
-        target  => $master,
-        content => "+dir:${map_dir}",
-        order   => $order,
+      if !defined(Concat::Fragment['autofs::fragment preamble map directory']) and $ensure == 'present' {
+        concat::fragment { 'autofs::fragment preamble map directory':
+          target  => $master,
+          content => "+dir:${map_dir}",
+          order   => $order,
+          require => File[$map_dir],
+        }
+      }
+
+      file { "${map_dir}/${name}.autofs":
+        ensure  => $ensure,
+        owner   => $autofs::map_file_owner,
+        group   => $autofs::map_file_group,
+        mode    => '0644',
+        content => $contents,
         require => File[$map_dir],
       }
-    }
-
-    file { "${map_dir}/${name}.autofs":
-      ensure  => $ensure,
-      owner   => $autofs::map_file_owner,
-      group   => $autofs::map_file_group,
-      mode    => '0644',
-      content => $contents,
-      require => File[$map_dir],
     }
   }
 
   if $mapfile and $mapfile_manage {
+    concat { $mapfile:
+      ensure  => $ensure,
+      owner   => $autofs::map_file_owner,
+      group   => $autofs::map_file_group,
+      mode    => $execute ? { true => '0755', default => '0644' },
+      replace => $replace,
+      force   => true,
+      warn    => template('autofs/map.banner.erb'),
+      require => Class['autofs::package'],
+    }
+
     autofs::map { $title:
       ensure      => $ensure,
       mapfile     => $mapfile,
       mapcontents => $mapcontents,
-      replace     => $replace,
-      template    => $maptempl,
-      mapmode     => $mapperms,
     }
   }
 }

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -121,13 +121,17 @@ define autofs::mount (
     fail("Parameter 'mapfile_manage' must be false for complicated 'mapfile' ${mapfile}")
   }
 
-  if $execute =~ NotUndef {
+  if $direct =~ NotUndef {
     deprecation('autofs::mount::direct',
         'Resource parameter $::autofs::mount::direct is deprecated and has no effect')
   }
 
   if !($master_manage or $mapfile_manage) {
     warn("Autofs::Mount[${title}] does not manage anything")
+  }
+
+  if (length($mapcontents) > 0) and !$mapfile_manage {
+    warn("Map file contents specified for autofs::mount[$title], but no map file is being managed")
   }
 
   if $mapfile {
@@ -188,7 +192,7 @@ define autofs::mount (
       }
     } else {
       ensure_resource('file', $map_dir, {
-        'ensure'  => directory,
+        'ensure'  => 'directory',
         'owner'   => $autofs::map_file_owner,
         'group'   => $autofs::map_file_group,
         'mode'    => '0755',

--- a/spec/acceptance/autofs_exec_spec.rb
+++ b/spec/acceptance/autofs_exec_spec.rb
@@ -41,6 +41,7 @@ describe 'autofs::mount exec tests' do
       its(:content) do
         is_expected.to start_with('#!/bin/bash')
         is_expected.to match(%r{^test_exec -o rw /mnt/test_exec$})
+        is_expected.not_to match(%r{^(?m)test.*\n#})
       end
     end
 
@@ -104,6 +105,7 @@ describe 'autofs::mount exec tests' do
       its(:content) do
         is_expected.to start_with('#!/bin/bash')
         is_expected.to match(%r{^test_exec -o rw /mnt/test_exec$})
+        is_expected.not_to match(%r{^(?m)test.*\n#})
       end
     end
 

--- a/spec/acceptance/autofs_map_spec.rb
+++ b/spec/acceptance/autofs_map_spec.rb
@@ -29,7 +29,7 @@ describe 'autofs::map tests' do
       end
       its(:content) do
         is_expected.to start_with('##')
-        is_expected.not_to match(/^(?m)data.*\n#/)
+        is_expected.not_to match %r{^(?m)data.*\n#}
       end
     end
 
@@ -75,7 +75,7 @@ describe 'autofs::map tests' do
       end
       its(:content) do
         is_expected.to start_with('##')
-        is_expected.not_to match(/^(?m)data.*\n#/)
+        is_expected.not_to match %r{^(?m)data.*\n#}
       end
     end
   end
@@ -109,7 +109,7 @@ describe 'autofs::map tests' do
       # The content should start with the warning banner
       its(:content) { is_expected.to start_with '##' }
       # After the first map line, the banner should not be repeated
-      its(:content) { is_expected.not_to match /^(?m)data.*\n#/ }
+      its(:content) { is_expected.not_to match %r{^(?m)data.*\n#} }
     end
   end
 end

--- a/spec/acceptance/autofs_mount_spec.rb
+++ b/spec/acceptance/autofs_mount_spec.rb
@@ -34,7 +34,7 @@ describe 'autofs::mount tests' do
       end
       its(:content) do
         is_expected.to start_with('##')
-        is_expected.not_to match(/^\s*[^#\n]/)
+        is_expected.not_to match %r{^\s*[^#\n]}
       end
     end
 

--- a/spec/acceptance/autofs_mount_spec.rb
+++ b/spec/acceptance/autofs_mount_spec.rb
@@ -1,0 +1,120 @@
+
+require 'spec_helper_acceptance'
+
+describe 'autofs::mount tests' do
+  context 'basic mount test' do
+    it 'applies' do
+      pp = <<-EOS
+        class { 'autofs': }
+        autofs::mount { '/mnt/data':
+          mapfile     => '/etc/auto.data',
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.master') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) { is_expected.to match(%r{^\s*/mnt/data\s+/etc/auto.data\s*$}) }
+    end
+
+    describe file('/etc/auto.data') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) do
+        is_expected.to start_with('##')
+        is_expected.not_to match(/^\s*[^#\n]/)
+      end
+    end
+
+    describe package('autofs') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('autofs') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+
+  context 'manage mapfile only' do
+    it 'applies' do
+      pp = <<-MANIFEST
+        class { 'autofs': }
+        autofs::mount { '/mnt/data2':
+          mapfile       => '/etc/auto.data2',
+          master_manage => false,
+          mapcontents   => [
+            'example -rw example.com:/path/to/data2'
+          ]
+        }
+      MANIFEST
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.master') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) { is_expected.not_to match(%r{^\s*/mnt/data2\s}) }
+    end
+
+    describe file('/etc/auto.data2') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) { is_expected.to match(%r{^example -rw example.com:/path/to/data2$}) }
+    end
+  end
+
+  context 'rmmap entire' do
+    it 'applies' do
+      pp = <<-MANIFEST
+        class { 'autofs': }
+        autofs::mount { 'data':
+          ensure        => 'absent',
+          mount         => '/mnt/data',
+          mapfile       => '/etc/auto.data',
+        }
+      MANIFEST
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.data') do
+      it 'does not exist' do
+        is_expected.not_to exist
+      end
+    end
+
+    describe file('/etc/auto.master') do
+      it 'exists and have content' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+        is_expected.to be_mode 644
+      end
+      its(:content) { is_expected.not_to match(%r{^\s*/mnt/data\s}) }
+    end
+  end
+end

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -24,12 +24,7 @@ describe 'autofs::map', type: :define do
 
       context 'with default parameters' do
         it do
-          is_expected.to contain_concat('/etc/auto.data').with(
-            'ensure' => 'present',
-            'owner'  => 'root',
-            'group'  => group,
-            'mode'   => '0644'
-          )
+          is_expected.not_to contain_concat('/etc/auto.data')
           is_expected.to contain_concat__fragment('/etc/auto.data_data_entries').with(
             'target' => '/etc/auto.data'
           )

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -4,12 +4,6 @@ describe 'autofs::map', type: :define do
   on_supported_os.each do |os, facts|
     let(:pre_condition) { 'include autofs' }
 
-    group = if facts[:os]['family'] == 'AIX'
-              'system'
-            else
-              'root'
-            end
-
     context "on #{os}" do
       let(:title) { 'data' }
       let(:facts) do

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -343,7 +343,7 @@ describe 'autofs::mount', type: :define do
             mapfile: '/etc/auto.data',
             mapcontents: %w[dataA dataB dataC],
             master_manage: false,
-            use_dir: true,
+            use_dir: true
           }
         end
 
@@ -365,7 +365,7 @@ describe 'autofs::mount', type: :define do
             mapfile: '/etc/auto.data',
             mapcontents: %w[dataA dataB dataC],
             master_manage: false,
-            use_dir: true,
+            use_dir: true
           }
         end
 

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -67,6 +67,7 @@ describe 'autofs::mount', type: :define do
 
         it do
           is_expected.not_to contain_file('/etc/auto.smb')
+          is_expected.not_to contain_concat('/etc/auto.smb')
           is_expected.to contain_concat__fragment('autofs::fragment preamble /smb /etc/auto.smb')
         end
       end
@@ -86,6 +87,7 @@ describe 'autofs::mount', type: :define do
         it do
           is_expected.to contain_concat__fragment('autofs::fragment preamble /smb program:/etc/auto.smb')
           is_expected.not_to contain_file('/etc/auto.smb')
+          is_expected.not_to contain_concat('/etc/auto.smb')
         end
       end
 
@@ -136,7 +138,50 @@ describe 'autofs::mount', type: :define do
         end
 
         it do
+          is_expected.to contain_concat('/etc/auto.home')
           is_expected.to contain_concat__fragment('autofs::fragment preamble /- /etc/auto.home')
+        end
+      end
+
+      context 'with EL7 directory' do
+        let(:params) do
+          {
+            name: 'home',
+            mount: '/home',
+            mapfile: '/etc/auto.home',
+            mapcontents: %w[test foo bar],
+            options: '--timeout=120',
+            order: 1,
+            map_dir: '/etc/auto.master.d',
+            use_dir: true
+          }
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('autofs::fragment preamble map directory')
+        end
+
+        it do
+          is_expected.to contain_file('/etc/auto.master.d').with(
+            'ensure' => 'directory',
+            'owner'  => 'root',
+            'group'  => group,
+            'mode'   => '0755'
+          )
+
+          is_expected.to contain_file('/etc/auto.master.d/home.autofs').with(
+            'ensure' => 'present',
+            'owner'  => 'root',
+            'group'  => group,
+            'mode'   => '0644'
+          )
+
+          is_expected.to contain_concat('/etc/auto.home').with(
+            'ensure' => 'present',
+            'owner'  => 'root',
+            'group'  => group,
+            'mode'   => '0644'
+          )
         end
       end
 
@@ -157,48 +202,43 @@ describe 'autofs::mount', type: :define do
         end
       end
 
-      [true, false].each do |execute|
-        context "with EL7 directory and #{execute ? '' : 'non-'}executable map" do
-          let(:params) do
-            {
-              name: 'home',
-              mount: '/home',
-              mapfile: '/etc/auto.home',
-              mapcontents: %w[test foo bar],
-              options: '--timeout=120',
-              order: 1,
-              map_dir: '/etc/auto.master.d',
-              use_dir: true,
-              execute: execute
-            }
-          end
+      context 'with EL7 directory and executable map' do
+        let(:params) do
+          {
+            name: 'home',
+            mount: '/home',
+            mapfile: '/etc/auto.home',
+            execute: true,
+            map_dir: '/etc/auto.master.d',
+            use_dir: true
+          }
+        end
 
-          it do
-            is_expected.to contain_concat__fragment('autofs::fragment preamble map directory')
-          end
+        it do
+          is_expected.to contain_concat__fragment('autofs::fragment preamble map directory')
+        end
 
-          it do
-            is_expected.to contain_file('/etc/auto.master.d').with(
-              'ensure' => 'directory',
-              'owner'  => 'root',
-              'group'  => group,
-              'mode'   => '0755'
-            )
+        it do
+          is_expected.to contain_file('/etc/auto.master.d').with(
+            'ensure' => 'directory',
+            'owner'  => 'root',
+            'group'  => group,
+            'mode'   => '0755'
+          )
 
-            is_expected.to contain_file('/etc/auto.master.d/home.autofs').with(
-              'ensure' => 'present',
-              'owner'  => 'root',
-              'group'  => group,
-              'mode'   => '0644'
-            )
+          is_expected.to contain_file('/etc/auto.master.d/home.autofs').with(
+            'ensure' => 'present',
+            'owner'  => 'root',
+            'group'  => group,
+            'mode'   => '0644'
+          )
 
-            is_expected.to contain_concat('/etc/auto.home').with(
-              'ensure' => 'present',
-              'owner'  => 'root',
-              'group'  => group,
-              'mode'   => execute ? '0755' : '0644'
-            )
-          end
+          is_expected.to contain_concat('/etc/auto.home').with(
+            'ensure' => 'present',
+            'owner'  => 'root',
+            'group'  => group,
+            'mode'   => '0755'
+          )
         end
       end
 
@@ -292,6 +332,50 @@ describe 'autofs::mount', type: :define do
           is_expected.not_to contain_concat__fragment('autofs::fragment preamble /data /etc/auto.data')
           is_expected.to contain_concat('/etc/auto.data').with_ensure('absent')
           is_expected.not_to contain_concat__fragment('/etc/auto.data_/data_entries')
+        end
+      end
+
+      context 'with master_manage false' do
+        let(:title) { 'data' }
+        let(:params) do
+          {
+            mount: '/data',
+            mapfile: '/etc/auto.data',
+            mapcontents: %w[dataA dataB dataC],
+            master_manage: false,
+            use_dir: true,
+          }
+        end
+
+        it do
+          is_expected.to compile
+          is_expected.not_to contain_concat(master_map_file)
+          is_expected.to contain_concat('/etc/auto.data').with_ensure('present')
+          is_expected.not_to contain_file('/etc/auto.master.d')
+          is_expected.not_to contain_file('/etc/auto.master.d/data.autofs')
+        end
+      end
+
+      context 'with master_manage false and ensure absent' do
+        let(:title) { 'data' }
+        let(:params) do
+          {
+            ensure: 'absent',
+            mount: '/data',
+            mapfile: '/etc/auto.data',
+            mapcontents: %w[dataA dataB dataC],
+            master_manage: false,
+            use_dir: true,
+          }
+        end
+
+        it do
+          is_expected.to compile
+          is_expected.not_to contain_concat(master_map_file)
+          is_expected.to have_file_line_resource_count(0)
+          is_expected.to contain_concat('/etc/auto.data').with_ensure('absent')
+          is_expected.not_to contain_file('/etc/auto.master.d')
+          is_expected.not_to contain_file('/etc/auto.master.d/data.autofs')
         end
       end
     end

--- a/templates/auto.map.erb
+++ b/templates/auto.map.erb
@@ -1,18 +1,3 @@
-<% if @replace == true or @replace == 'yes' -%>
-###############################################################
-#                                                             #
-# THIS FILE IS MANAGED BY PUPPET. ANY CHANGES MADE TO THIS    #
-#   FILE WILL BE REVERTED BACK ON THE NEXT PUPPET RUN.        #
-#                                                             #
-###############################################################
-<% else -%>
-###############################################################
-#                                                             #
-# THIS FILE IS NOT MANAGED BY PUPPET. USE THIS FILE FOR       #
-#    CUSTOM / TEMPORARY MOUNT POINTS CONFIGURATIONS.          #
-#                                                             #
-###############################################################
-<% end -%>
 
 <% [@mapcontents].flatten.each do |content| -%>
 <%= content %>

--- a/templates/map.banner.erb
+++ b/templates/map.banner.erb
@@ -1,4 +1,6 @@
+<% if @execute -%>
 #!/bin/bash
+<% end -%>
 <% if @replace == true or @replace == 'yes' -%>
 ###############################################################
 #                                                             #
@@ -13,8 +15,4 @@
 #    CUSTOM / TEMPORARY MOUNT POINTS CONFIGURATIONS.          #
 #                                                             #
 ###############################################################
-<% end -%>
-
-<% [@mapcontents].flatten.each do |content| -%>
-<%= content %>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
The changes in this pull request have two main thrusts:

 1. Enabling entries in the master map and overall map files to be managed independently of each other, and
 2. Eliminating opportunities for map file properties to be specified inconsistently, such as are the underlying cause of issues #104 and #107.

It attempts to accomplish this as much as possible within the framework already in place, via two key changes:

 1. Adding a `master_manage` property to `autofs::mount` to control whether that resource manages an entry in the master map, and

 2. Moving management of overall map file parameters (via the appropriate `Concat` resource) out of `autofs::map`, back to `autofs::mount`.

In addition to fixing several open issues, this has the welcome effect of making the odd behavior of `autofs::map::ensure` more consistent with other resources.

#### This Pull Request (PR) fixes the following issues
Fixes #103 
Fixes #104 
Fixes #107 
