### PR TITLE
Closes #127: Add support for Darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,9 +677,9 @@ Compatible with Puppet 4 or greater only. Puppet 4.6.0 or greater
     * Fedora 24, 25
     * SLES 10
     * CentOS/RHEL/Scientific/Oracle Linux 5.x
+    * Mac OS X
 * Unsupported
     * Windows (Autofs not available)
-    * Mac OS X
 
 Development
 -------------

--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -1,0 +1,8 @@
+---
+autofs::package_name: []
+autofs::service_name:
+  - com.apple.autofsd
+  - com.apple.automountd
+autofs::auto_master_map: /etc/auto_master
+autofs::map_file_group: wheel
+autofs::reload_command: /usr/sbin/automount -vc

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@
 # @param service_enable Determines if the service should start with the system boot. true
 #   will start the autofs service on boot. false will not start the autofs service
 #   on boot.
-# @param service_name Determine the name of the service for cross platform compatibility
+# @param service_name Determine the name of the service(s) for cross platform compatibility
 # @param auto_master_map Filename of the auto.master map for cross platform compatiblity
 # @param map_file_owner owner of the automount map files for cross platform compatiblity
 # @param map_file_group group of the automount map files for cross platform compatiblity
@@ -88,7 +88,7 @@ class autofs (
   Variant[String, Array[String]] $package_name,
   Enum[ 'stopped', 'running' ] $service_ensure,
   Boolean $service_enable,
-  String $service_name,
+  Variant[String, Array[String]] $service_name,
   String $auto_master_map,
   String $map_file_owner,
   String $map_file_group,

--- a/metadata.json
+++ b/metadata.json
@@ -80,6 +80,15 @@
         "7.1",
         "7.2"
       ]
+    },
+    {
+      "operatingsystem": "Darwin",
+      "operatingsystemrelease": [
+        "10.9",
+        "10.10",
+        "10.11",
+        "10.12"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -18,6 +18,9 @@ describe 'autofs', type: :class do
                   'SUNWatfsu' # and SUNWatfsr, but close enough
                 end
       service = 'autofs'
+    when 'Darwin'
+      service = ['com.apple.automountd', 'com.apple.autofsd']
+      package = []
     else
       package = 'autofs'
       service = 'autofs'
@@ -123,6 +126,13 @@ describe 'autofs', type: :class do
       it 'is expected to fail' do
         is_expected.to compile.and_raise_error(%r{parameter 'mounts' expects a Hash value})
       end
+    end
+
+    context 'parameter $service_name works with arrays' do
+      let(:params) { { service_name: ['com.apple.autofsd', 'com.apple.automountd'] } }
+
+      it { is_expected.to contain_service('com.apple.autofsd').with_ensure('running') }
+      it { is_expected.to contain_service('com.apple.automountd').with_ensure('running') }
     end
   end
 end


### PR DESCRIPTION
I tested this simple extention against MacOS 10.10,10.11,10.12. The
same thing also works on MacOS 10.9, so I added it also.

On Darwin, we need to handle two services: I changed `$service_name` to
a variant to accept arrays.