### PR TITLE
autofs::mapfile can be configured to be executable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,18 @@ Whichever form is used, the resulting mapping in file `/etc/auto.home` is
 *	-rw,soft,intr	server.example.com:/path/to/home/shares
 ```
 
+#### Executable map files
+
+By default, map files are marked as `0644`. If a map file must be executable, 
+you can set the `execute` parameter to enforce `0755`.
+
+```puppet
+autofs::mapfile { 'home':
+  path    => '/etc/auto.data',
+  execute => true
+}
+```
+
 #### Multiple mappings in the same file
 
 Multiple mappings may be declared for the same map file, either in the same
@@ -572,6 +584,14 @@ any that are specified for this map file via separate `autofs::mapping`
 resources.
 
 Default: `true`
+
+#### `execute`
+
+Data type: Boolean
+
+This parameter specifies whether this map file should be executable.
+
+Default: `false`
 
 ### Parameters for autofs::mapping
 

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -16,6 +16,7 @@
 #     mappings can be specified for this mapfile via autofs::mapping resources
 # @param replace Whether to replace the contents of any an existing file
 #     at the specified path
+# @param execute Whether to make the mapfile executable or not
 #
 define autofs::mapfile (
   Enum['present', 'absent'] $ensure   = 'present',

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -22,6 +22,7 @@ define autofs::mapfile (
   Stdlib::Absolutepath $path          = $title,
   Array[Autofs::Fs_mapping] $mappings = [],
   Boolean $replace                    = true,
+  Boolean $execute                    = false,
 ) {
   include '::autofs'
 
@@ -38,11 +39,16 @@ define autofs::mapfile (
     }
   }
 
+  $mapfile_mode = $execute ? {
+    true => '0755',
+    false => '0644'
+  }
+
   concat { $path:
     ensure  => $ensure,
     owner   => $autofs::map_file_owner,
     group   => $autofs::map_file_group,
-    mode    => '0644',
+    mode    => $mapfile_mode,
     replace => $replace,
     require => Class['autofs::package'],
     warn    => template('autofs/mapfile.banner.erb'),

--- a/spec/defines/mapfile_spec.rb
+++ b/spec/defines/mapfile_spec.rb
@@ -12,7 +12,7 @@ describe 'autofs::mapfile', type: :define do
           is_expected.to compile
           is_expected.to contain_class('autofs')
           is_expected.to contain_concat('/etc/auto.data').
-            with(ensure: 'present', replace: true)
+            with(ensure: 'present', replace: true, mode: '0644')
         end
       end
 
@@ -39,6 +39,18 @@ describe 'autofs::mapfile', type: :define do
           is_expected.to contain_class('autofs')
           is_expected.to contain_concat('/etc/auto.data').
             with(ensure: 'present', replace: false)
+        end
+      end
+
+      context 'with execute' do
+        let(:title) { '/etc/auto.data' }
+        let(:params) { { execute: true } }
+
+        it do
+          is_expected.to compile
+          is_expected.to contain_class('autofs')
+          is_expected.to contain_concat('/etc/auto.data').
+            with(ensure: 'present', mode: '0755')
         end
       end
 


### PR DESCRIPTION
#### Pull Request (PR) description

:tipping_hand_woman: This PR makes it possible to manage map files that should be executable.

Today, there seems to be no way to manage map files that should be marked `0755`. We used to be able to do this in `4.3.0` (See: [`$mapperms` assignment via `$execute`](https://github.com/voxpupuli/puppet-autofs/blob/9aa15f4909d82efb995ea098d6b85236be672e02/manifests/mount.pp#L85-L92) and [`$mapperms` usage](https://github.com/voxpupuli/puppet-autofs/blob/v4.3.0/manifests/mount.pp#L167))

:face_with_head_bandage: Currently, in our `mounted_storage` profile, we apply a workaround as follows:

```puppet
$mounts_param.each | $title, $config | {
  autofs::mount { $title:
    mount       => $config['mount'],
    mapfile     => $config['mapfile'],
    options     => $config['options']
  }

  if $config['execute'] == true {
    Concat <| title == $config['mapfile'] |> {
      mode => '0755'
    }
  }

  autofs::mapfile { $title:
    path     => $config['mapfile'],
    mappings => $config['mappings']
  }
}
```

:grinning: With this patch, I could instead:

```puppet
$mounts_param.each | $title, $config | {
  autofs::mount { $title:
    mount       => $config['mount'],
    mapfile     => $config['mapfile'],
    options     => $config['options']
  }

  autofs::mapfile { $title:
    path     => $config['mapfile'],
    mappings => $config['mappings'],
    execute => $config['execute']
  }
}
```