### PR TITLE
Add optional integer "order" to fs_mapping type

### DIFF
--- a/spec/acceptance/autofs_mapping_spec.rb
+++ b/spec/acceptance/autofs_mapping_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper_acceptance'
+
+describe 'autofs::mapping tests' do
+  context 'basic mapping test' do
+    it 'applies' do
+      pp = <<-EOS
+        autofs::mapfile { '/etc/auto.data':
+        }
+        autofs::mapping { 'dataA':
+          mapfile => '/etc/auto.data',
+          key     => 'dataA',
+          options => 'ro',
+          fs      => 'fs.net:/export/dataA',
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.data') do
+      it 'exists and belongs to root' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+      end
+      its(:content) do
+        is_expected.to match %r{^\s*dataA\s+-ro\s+fs.net:/export/dataA\s*$}
+      end
+    end
+  end
+
+  context 'with order parameter' do
+    it 'applies' do
+      pp = <<-EOS
+        autofs::mapfile { '/etc/auto.data':
+          mappings => [
+            { 'key' => 'dataB', 'options' => 'rw,noexec', 'fs' => 'fs.net:/export/dataB', 'order' => 20 },
+          ]
+        }
+        autofs::mapping { 'dataA':
+          mapfile => '/etc/auto.data',
+          key     => 'dataA',
+          options => 'ro',
+          fs      => 'fs.net:/export/dataA',
+          order   => 10,
+        }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/auto.data') do
+      it 'exists and belongs to root' do
+        is_expected.to exist
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+      end
+      its(:content) do
+        is_expected.to match %r{^\s*dataA\s+-ro\s+fs.net:/export/dataA\s*\n\s*dataB\s+-rw,noexec\s+fs.net:/export/dataB\s*$}
+      end
+    end
+  end
+end

--- a/types/fs_mapping.pp
+++ b/types/fs_mapping.pp
@@ -19,5 +19,6 @@
 type Autofs::Fs_mapping = Struct[{
   key     => Pattern[/\A\S+\z/],
   options => Optional[Autofs::Options],
+  order   => Optional[Integer],
   fs      => Pattern[/\S/]  # contains at least one non-whitespace character
 }]


### PR DESCRIPTION
#### Add optional integer "order" to fs_mapping type
I have multiple autofs mapfiles and mappings defined in hiera. I needed to change the order of the mappings in one of the mapfiles, and adding the order key to the mappings threw an error (`parameter 'mappings' index 0 unrecognized key 'order'`).

This change seems to fix the problem.
