### PR TITLE
Correct variable use in spec tests

### DIFF
--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -4,35 +4,26 @@ require 'hiera'
 describe 'autofs', type: :class do
   let(:hiera_config) { 'spec/fixtures/hiera/hiera.yaml' }
 
-  # hiera = Hiera.new(config: 'spec/fixtures/hiera/hiera.yaml')
-
-  on_supported_os.each do |os, facts|
-    case facts[:os]['family']
-    when 'AIX'
-      package = 'bos.net.nfs.client'
-      service = 'automountd'
-    when 'Solaris'
-      package = if facts[:os]['release']['major'].to_s == '11'
-                  'system/file-system/autofs'
-                else
-                  'SUNWatfsu' # and SUNWatfsr, but close enough
-                end
-      service = 'autofs'
-    else
-      package = 'autofs'
-      service = 'autofs'
-    end
-
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let :facts do
-        facts
+      let(:facts) { os_facts }
+      let(:service) { facts[:os]['family'] == 'AIX' ? 'automountd' : 'autofs' }
+      let(:package) do
+        case facts[:os]['family']
+        when 'AIX'
+          'bos.net.nfs.client'
+        when 'Solaris'
+          if facts[:os]['release']['major'].to_s == '11'
+            'system/file-system/autofs'
+          else
+            'SUNWatfsu' # and SUNWatfsr, but close enough
+          end
+        else
+          'autofs'
+        end
       end
 
       context 'main init tests' do
-        let(:facts) do
-          facts.merge(concat_basedir: '/etc')
-        end
-
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('autofs') }
         it { is_expected.to contain_class('autofs::package') }
@@ -44,84 +35,81 @@ describe 'autofs', type: :class do
         it { is_expected.to contain_service(service).with_ensure('running') }
         it { is_expected.to contain_service(service).with_enable(true) }
       end
-    end
 
-    context 'disable package' do
-      let(:facts) do
-        facts.merge(concat_basedir: '/etc')
-      end
-      let(:params) do
-        {
-          package_ensure: 'absent'
-        }
-      end
-
-      it { is_expected.to contain_package(package).with_ensure('absent') }
-    end
-
-    context 'should declare mount points' do
-      let(:params) do
-        {
-          mounts: {
-            'home'        => { mount: '/home', mapfile: '/etc/auto.home', options: '--timeout=120', order: 1 },
-            '/mnt/other'  => { mapfile: '/etc/auto.other' },
-            'direct'      => { mount: '/-', mapfile: '/etc/auto.direct' },
-            'remove this' => { mount: '/unwanted', mapfile: '/etc/auto.unwanted', ensure: 'absent' }
+      context 'disable package' do
+        let(:params) do
+          {
+            package_ensure: 'absent'
           }
-        }
+        end
+
+        it { is_expected.to contain_package(package).with_ensure('absent') }
       end
 
-      it do
-        is_expected.to compile.with_all_deps
-        is_expected.to have_autofs__mount_resource_count(4)
-        is_expected.to contain_autofs__mount('home').
-          with(mount: '/home', mapfile: '/etc/auto.home', options: '--timeout=120', order: 1)
-        is_expected.to contain_autofs__mount('/mnt/other').
-          with(mapfile: '/etc/auto.other')
-        is_expected.to contain_autofs__mount('direct').
-          with(mount: '/-', mapfile: '/etc/auto.direct')
-        is_expected.to contain_autofs__mount('remove this').
-          with(mount: '/unwanted', ensure: 'absent')
-        is_expected.to have_autofs__map_resource_count(0)
-        is_expected.to have_autofs__mapfile_resource_count(0)
-        is_expected.to have_autofs__mapping_resource_count(0)
-      end
-    end
+      context 'should declare mount points' do
+        let(:params) do
+          {
+            mounts: {
+              'home'        => { mount: '/home', mapfile: '/etc/auto.home', options: '--timeout=120', order: 1 },
+              '/mnt/other'  => { mapfile: '/etc/auto.other' },
+              'direct'      => { mount: '/-', mapfile: '/etc/auto.direct' },
+              'remove this' => { mount: '/unwanted', mapfile: '/etc/auto.unwanted', ensure: 'absent' }
+            }
+          }
+        end
 
-    context 'should declare map files' do
-      home_mappings = [
-        { 'key' => 'user1', 'options' => 'rw,exec', 'fs' => 'users.com:/x/user1' }
-      ]
-      let(:params) do
-        {
-          mounts: {},
-          mapfiles: {
-            'home' => { path: '/etc/auto.home', mappings: home_mappings },
-            '/mnt/defaults' => {},
-            'unwanted' => { path: '/etc/auto.evil', ensure: 'absent' }
-          },
-          maps: :undef
-        }
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to have_autofs__mount_resource_count(4)
+          is_expected.to contain_autofs__mount('home').
+            with(mount: '/home', mapfile: '/etc/auto.home', options: '--timeout=120', order: 1)
+          is_expected.to contain_autofs__mount('/mnt/other').
+            with(mapfile: '/etc/auto.other')
+          is_expected.to contain_autofs__mount('direct').
+            with(mount: '/-', mapfile: '/etc/auto.direct')
+          is_expected.to contain_autofs__mount('remove this').
+            with(mount: '/unwanted', ensure: 'absent')
+          is_expected.to have_autofs__map_resource_count(0)
+          is_expected.to have_autofs__mapfile_resource_count(0)
+          is_expected.to have_autofs__mapping_resource_count(0)
+        end
       end
 
-      it do
-        is_expected.to compile.with_all_deps
-        is_expected.to contain_autofs__mapfile('home').
-          with(path: '/etc/auto.home', mappings: home_mappings)
-        is_expected.to contain_autofs__mapfile('/mnt/defaults')
-        is_expected.to contain_autofs__mapfile('unwanted').
-          with(path: '/etc/auto.evil', ensure: 'absent')
-        is_expected.to have_autofs__mapfile_resource_count(3)
-        is_expected.to have_autofs__mount_resource_count(0)
-        is_expected.to have_autofs__map_resource_count(0)
+      context 'should declare map files' do
+        home_mappings = [
+          { 'key' => 'user1', 'options' => 'rw,exec', 'fs' => 'users.com:/x/user1' }
+        ]
+        let(:params) do
+          {
+            mounts: {},
+            mapfiles: {
+              'home' => { path: '/etc/auto.home', mappings: home_mappings },
+              '/mnt/defaults' => {},
+              'unwanted' => { path: '/etc/auto.evil', ensure: 'absent' }
+            },
+            maps: :undef
+          }
+        end
+
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_autofs__mapfile('home').
+            with(path: '/etc/auto.home', mappings: home_mappings)
+          is_expected.to contain_autofs__mapfile('/mnt/defaults')
+          is_expected.to contain_autofs__mapfile('unwanted').
+            with(path: '/etc/auto.evil', ensure: 'absent')
+          is_expected.to have_autofs__mapfile_resource_count(3)
+          is_expected.to have_autofs__mount_resource_count(0)
+          is_expected.to have_autofs__map_resource_count(0)
+        end
       end
-    end
 
-    context 'with $mounts not a hash' do
-      let(:params) { { mounts: 'string' } }
+      context 'with $mounts not a hash' do
+        let(:params) { { mounts: 'string' } }
 
-      it 'is expected to fail' do
-        is_expected.to compile.and_raise_error(%r{parameter 'mounts' expects a Hash value})
+        it 'is expected to fail' do
+          is_expected.to compile.and_raise_error(%r{parameter 'mounts' expects a Hash value})
+        end
       end
     end
   end

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -1,20 +1,12 @@
 require 'spec_helper'
 
 describe 'autofs::map', type: :define do
-  on_supported_os.each do |os, facts|
-    let(:pre_condition) { 'include autofs' }
-
-    group = if facts[:os]['family'] == 'AIX'
-              'system'
-            else
-              'root'
-            end
-
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:title) { 'data' }
-      let(:facts) do
-        facts.merge(concat_basedir: '/etc')
-      end
+      let(:pre_condition) { 'include autofs' }
+      let(:group) { facts[:os]['family'] == 'AIX' ? 'system' : 'root' }
+      let(:facts) { os_facts }
       let(:params) do
         {
           mapfile: '/etc/auto.data',
@@ -37,12 +29,7 @@ describe 'autofs::map', type: :define do
       end
 
       context 'with bare string mapcontents' do
-        let(:params) do
-          {
-            mapfile: '/etc/auto.data',
-            mapcontents: 'test foo bar'
-          }
-        end
+        let(:params) { super().merge(mapcontents: 'test foo bar') }
 
         it { is_expected.to compile }
       end

--- a/spec/defines/mapfile_spec.rb
+++ b/spec/defines/mapfile_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'autofs::mapfile', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { os_facts }
 
       context 'with default parameters' do
         let(:title) { '/etc/auto.data' }

--- a/spec/defines/mapping_spec.rb
+++ b/spec/defines/mapping_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'autofs::mapping', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { os_facts }
       let(:title) { 'data' }
 
       context 'with no options' do

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -1,25 +1,12 @@
 require 'spec_helper'
 describe 'autofs::mount', type: :define do
-  on_supported_os.each do |os, facts|
-    let(:pre_condition) { 'include autofs' }
-
-    case facts[:os]['family']
-    when 'AIX'
-      group = 'system'
-      master_map_file = '/etc/auto_master'
-    when 'Solaris'
-      group = 'root'
-      master_map_file = '/etc/auto_master'
-    else
-      group = 'root'
-      master_map_file = '/etc/auto.master'
-    end
-
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:title) { 'auto.home' }
-      let(:facts) do
-        facts.merge(concat_basedir: '/etc')
-      end
+      let(:pre_condition) { 'include autofs' }
+      let(:group) { facts[:os]['family'] == 'AIX' ? 'system' : 'root' }
+      let(:master_map_file) { %w[AIX Solaris].include?(facts[:os]['family']) ? '/etc/auto_master' : '/etc/auto.master' }
+      let(:facts) { os_facts }
 
       context 'with default parameters' do
         let(:params) do


### PR DESCRIPTION
Using variables leads to unpredictable results. This uses the correct let() blocks which has the correct scoping.