### PR TITLE
Enable LDAP in autofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Autofs Puppet Module
-====================
+# Autofs Puppet Module
 
 [![Travis branch](https://img.shields.io/travis/voxpupuli/puppet-autofs/master.svg?style=flat-square)](https://travis-ci.org/voxpupuli/puppet-autofs)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/autofs.svg?style=flat-square)](https://forge.puppetlabs.com/puppet/autofs)
@@ -7,7 +6,8 @@ Autofs Puppet Module
 [![Puppet Forge](https://img.shields.io/puppetforge/e/puppet/autofs.svg?style=flat-square)](https://forge.puppet.com/puppet/autofs)
 [![Puppet Forge](https://img.shields.io/puppetforge/f/puppet/autofs.svg?style=flat-square)](https://forge.puppet.com/puppet/autofs)
 
-#### Table of Contents
+## Table of Contents
+
 1. [Description - - What the module does and why it is useful](#description)
 2. [Setup - The basics of getting started with Autofs](#setup)
   * [The module manages the following](#the-module-manages-the-following)
@@ -19,16 +19,17 @@ Autofs Puppet Module
 5. [Development - Guide for contributing to the module](#development)
 6. [Support - When you need help with this module](#support)
 
-Description
------------
+### Description
+
 The Autofs module is a Puppet module for managing the configuration of on-demand mounting and
 automatic unmounting of local and remote filesystems via autofs / automount. This is a global
 module designed to be used by any organization.  It enables most details of Autofs
 configuration to be specified via the user's choice of Puppet manifest or external data.
 
-Setup
------
-### The Module manages the following:
+### Setup
+
+The Module manages the following:
+
 * Autofs package
 * Autofs service
 * Autofs master map (/etc/auto.master)
@@ -67,7 +68,7 @@ class { 'autofs':
 }
 ```
 
-### Master Map
+#### Master Map
 
 The module provides two compatible, built-in mechanisms for managing the
 content of the master map: by setting the `mounts` parameter of the `autofs`
@@ -97,7 +98,7 @@ autofs::mount { 'home':
 `$autofs::mounts`, will result in the following entry in the master
 map"
 
-```
+```sh
 /home /etc/auto.home --timeout=120
 ```
 
@@ -136,7 +137,6 @@ For more information about merge behavior see the doc for:
 * [Lookup docs](https://docs.puppet.com/puppet/4.7/lookup_quick.html#puppet-lookup:-quick-reference-for-hiera-users)
 * [Hiera 5 docs](https://docs.puppet.com/puppet/5.1/hiera_merging.html) if using Puppet >= 4.9
 
-
 #### Direct Map `/-` argument
 
 The autofs module supports Autofs direct maps naturally.  For a direct map,
@@ -148,7 +148,8 @@ directories; this module does *not* validate that constraint.
 ##### example
 
 Define:
-``` puppet
+
+```puppet
 autofs::mount { 'foo':
   mount       => '/-',
   mapfile     => '/etc/auto.foo',
@@ -157,7 +158,8 @@ autofs::mount { 'foo':
 ```
 
 Hiera:
-``` yaml
+
+```yaml
 autofs::mounts:
   foo:
     mount: '/-'
@@ -179,6 +181,7 @@ drop-in directory.
 ##### example
 
 Define:
+
 ```puppet
 autofs::mount { 'home':
   mount       => '/home',
@@ -189,6 +192,7 @@ autofs::mount { 'home':
 ```
 
 Hiera:
+
 ```yaml
 autofs::mounts:
   home:
@@ -210,6 +214,7 @@ also be sufficient to simply omit unwanted mount points.
 ##### example
 
 Define:
+
 ```puppet
 autofs::mount { 'home':
   ensure      => 'absent',
@@ -219,6 +224,7 @@ autofs::mount { 'home':
 ```
 
 Hiera:
+
 ```yaml
 autofs::mounts:
   home:
@@ -227,7 +233,7 @@ autofs::mounts:
     mapfile: '/etc/auto.home'
 ```
 
-### Map Files
+#### Map Files
 
 The module also provides two compatible, built-in mechanisms for managing
 Autofs map files: by setting the `mapfiles` parameter of the `autofs`
@@ -271,8 +277,8 @@ autofs::mapfiles:
 
 Whichever form is used, the resulting mapping in file `/etc/auto.home` is
 
-```
-*	-rw,soft,intr	server.example.com:/path/to/home/shares
+```sh
+* -rw,soft,intr server.example.com:/path/to/home/shares
 ```
 
 #### Executable map files
@@ -315,9 +321,9 @@ autofs::mapping { '/mnt/data_dataB':
 
 The resulting content of file `/mnt/data` would be
 
-```
-dataA	-ro	remote.com:/exports/dataA
-dataB	-rw,noexec	remote.com:/exports/dataB
+```sh
+dataA -ro remote.com:/exports/dataA
+dataB -rw,noexec remote.com:/exports/dataB
 ```
 
 #### Removing Entries
@@ -336,6 +342,29 @@ autofs::mapping { 'data':
   key         => 'dataA'
   fs          => 'example.com:/exports/dataA'
 }
+```
+
+#### LDAP configuration
+
+To setup autofs with an LDAP backend, some additional options need to be added to apply LDAP settings to the autofs configuration.  The first involves the `/etc/auth_ldap.conf` configuration file using the `$ldap_auth_config` hash.  The second is configuring the service itself with the service configuration file (in `/etc/default` or `/etc/sysconfig` depending on the operating system) using `$service_conf_options`.  It is also necessary to enable managing of these two files, which are not managed by default, using `$manage_ldap_auth_conf` and `$manage_service_config`.
+
+##### example
+
+```yaml
+autofs::ldap_auth_config:
+  usetls: 'yes'
+  tlsrequired: 'yes'
+  authrequired: 'no'
+autofs::manage_ldap_auth_conf: true
+autofs::manage_service_config: true
+autofs::service_conf_options:
+  ENTRY_ATTRIBUTE: 'cn'
+  ENTRY_OBJECT_CLASS: 'automount'
+  LDAP_URI: 'ldap://ldap.example.org'
+  MAP_ATTRIBUTE: 'ou'
+  MAP_OBJECT_CLASS: 'automountMap'
+  SEARCH_BASE: 'ou=automount,dc=autofs,dc=example,dc=org'
+  VALUE_ATTRIBUTE: 'automountInformation'
 ```
 
 ## Reference
@@ -565,6 +594,7 @@ wide variety of Autofs-recognized alternatives such as shared mounts,
 multi-mounts, and replicated mounts.
 
 Example:
+
 ```puppet
 [
   { 'key' => 'dataA', 'options' => 'rw,noexec', 'fs' => 'remote.net:/exports/dataA' }
@@ -656,11 +686,10 @@ mapping for the same key.
 
 Default: 10
 
+## Limitations
 
-Limitations
-------------
+### Removals
 
-#### Removals
 Directly calling the `autofs::package` and `autofs::service` classes is disabled in 3.0.0.
 These are now private classes.
 
@@ -671,43 +700,42 @@ The `direct`, `executable`, `mapcontents`, `mapfile_manage`, and `replace` param
 `autofs::mount` are removed in 5.0.0, the first having already been ineffective in 4.3.0,
 and the others no longer being relevant starting in 5.0.0.
 
-#### Puppet platforms
+### Puppet platforms
+
 Compatible with Puppet 4 or greater only. Puppet 4.6.0 or greater
 (including Puppet 5) will provide best results.
 
-#### Operating Systems
+### Operating Systems
 
 * Supported
-    * Ubuntu
-      * 16.04
-      * 18.04
-    * CentOS/RHEL/Scientific/Oracle Linux
-      * 6.x
-      * 7.x
-    * SLES
-      * 11 Service Pack 4
-      * 12 Service Pack 1
-    * OpenSUSE 13.1
-    * Debian
-      * 7 "Wheezy"
-      * 8 "Jessie"
+  * Ubuntu
+    * 16.04
+    * 18.04
+  * CentOS/RHEL/Scientific/Oracle Linux
+    * 6.x
+    * 7.x
+  * SLES
+    * 11 Service Pack 4
+    * 12 Service Pack 1
+  * OpenSUSE 13.1
+  * Debian
+    * 7 "Wheezy"
+    * 8 "Jessie"
 * Self Support - should work, support not provided by developer
-    * Solaris 10, 11
-    * AIX 7.1, 7.2
-    * Fedora 24, 25
-    * SLES 10
-    * CentOS/RHEL/Scientific/Oracle Linux 5.x
+  * Solaris 10, 11
+  * AIX 7.1, 7.2
+  * Fedora 24, 25
+  * SLES 10
+  * CentOS/RHEL/Scientific/Oracle Linux 5.x
 * Unsupported
-    * Windows (Autofs not available)
-    * Mac OS X
+  * Windows (Autofs not available)
+  * Mac OS X
 
-Development
--------------
+## Development
 
 Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for instructions regarding development environments and testing.
 
-Authors
--------
+## Authors
 
 * Vox Pupuli: [voxpupuli@groups.io](mailto:voxpupuli@groups.io)
 * David Hollinger: [david.hollinger@moduletux.com](mailto:david.hollinger@moduletux.com)

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,2 @@
+---
+autofs::service_conf_path: '/etc/default/autofs'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,3 +10,14 @@ autofs::auto_master_map: /etc/auto.master
 autofs::map_file_owner: root
 autofs::map_file_group: root
 autofs::reload_command: null
+autofs::manage_service_config: false
+autofs::manage_ldap_auth_conf: false
+autofs::service_use_misc_device: 'yes'
+autofs::service_options: ~
+autofs::service_conf_options: ~
+autofs::service_conf_path: '/etc/sysconfig/autofs'
+autofs::ldap_auth_conf_path: /etc/autofs_ldap_auth.conf
+autofs::ldap_auth_config:
+  usetls: 'no'
+  tlsrequired: 'no'
+  authrequired: 'no'

--- a/lib/facter/autofs_version.rb
+++ b/lib/facter/autofs_version.rb
@@ -3,7 +3,7 @@ Facter.add(:autofs_version) do
   setcode do
     if Facter::Util::Resolution.which('automount')
       autofs_version_command = 'automount -V 2>&1'
-      autofs_version = Facter::Core::Execution.execute(autofs_version_command)
+      autofs_version = Facter::Util::Resolution.exec(autofs_version_command)
       %r{Linux automount version ([\w\.]+)}.match(autofs_version)[1]
     end
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,11 @@
 #   string or array form, and a filesystem specification as expected by the 'mount'
 #   command.
 # @option mapfiles [Boolean] replace: whether to modify the map file if it already exists
+# @option ldap_auth_conf_path The path to the ldap_auth.conf file
+# @option ldap_auth_config The hash to use for the configuration settings in the ldap_auth.conf file
+# @option service_conf_path The path to the service configuration file
+# @option service_options An array of options to add to the OPTIONS variable in the service configuration file
+# @option service_conf_options A hash of environment variables to add to the service configuration file for LDAP configuration
 # @param maps Deprecated.  Use the mapfiles parameter instead.
 # @param package_ensure Determines the state of the package. Can be set to: installed, absent, lastest, or a specific version string.
 # @param package_name Determine the name of the package to install. Should be covered by hieradata.
@@ -78,6 +83,9 @@
 # @param auto_master_map Filename of the auto.master map for cross platform compatiblity
 # @param map_file_owner owner of the automount map files for cross platform compatiblity
 # @param map_file_group group of the automount map files for cross platform compatiblity
+# @param manage_service_config Determines if the service configuration file (in /etc/default or /etc/sysconfig) should be managed
+# @param manage_ldap_auth_conf Determines if the /etc/autofs_ldap_auth.conf file should be managed
+# @param service_use_misc_device Sets the USE_MISC_DEVICE value in the service configuration file
 # @param reload_command In lieu of a service reload capability in Puppet, exec this command to reload automount without restarting it.
 #
 class autofs (
@@ -90,10 +98,18 @@ class autofs (
   String $auto_master_map,
   String $map_file_owner,
   String $map_file_group,
+  Boolean $manage_service_config,
+  Boolean $manage_ldap_auth_conf,
+  Enum['no', 'yes'] $service_use_misc_device,
+  Optional[Stdlib::Absolutepath] $ldap_auth_conf_path,
+  Optional[Hash] $ldap_auth_config,
+  Optional[Stdlib::Absolutepath] $service_conf_path,
   Optional[Hash[String, Hash]] $mapfiles = undef,
   Optional[Hash[String, Hash]] $maps = undef,  # deprecated
   Optional[String] $package_source = undef,
   Optional[String] $reload_command = undef,
+  Optional[Array[String]] $service_options = undef,
+  Optional[Hash] $service_conf_options = undef,
 ) {
   contain 'autofs::package'
   unless $package_ensure == 'absent' {

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -16,7 +16,7 @@
 #   }
 #
 # @param ensure Whether to create the mapfile or not.
-# @param mapcontents The mount point options and parameters, 
+# @param mapcontents The mount point options and parameters,
 #   Example: '* -user,rw,soft nfs.example.org:/path/to'
 # @param mapfile Name of the "auto." configuration file that will be generated.
 # @param template Template to use to generate the mapfile.
@@ -48,14 +48,15 @@ define autofs::map (
     }
   }
 
-  ensure_resource(concat,$mapfile,{
+  ensure_resource(concat, $mapfile, {
       ensure  => $ensure,
       owner   => $autofs::map_file_owner,
       group   => $autofs::map_file_group,
       mode    => $mapmode,
       replace => $replace,
       require => Class['autofs::package'],
-  })
+    }
+  )
 
   unless $ensure == 'absent' {
     concat::fragment { "${mapfile}_${name}_entries":

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -113,14 +113,16 @@ define autofs::mount (
         notify            => Service[$autofs::service_name],
       }
     }
-  } else { # $use_dir == true
+  } else {
+    # $use_dir == true
     ensure_resource('file', $map_dir, {
-        'ensure'  => directory,
-        'owner'   => $autofs::map_file_owner,
-        'group'   => $autofs::map_file_group,
-        'mode'    => '0755',
-        'require' => Class['autofs::package'],
-    })
+        ensure  => directory,
+        owner   => $autofs::map_file_owner,
+        group   => $autofs::map_file_group,
+        mode    => '0755',
+        require => Class['autofs::package'],
+      }
+    )
 
     if !defined(Concat::Fragment['autofs::fragment preamble map directory']) and $ensure == 'present' {
       concat::fragment { 'autofs::fragment preamble map directory':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,48 @@
 #
 class autofs::service {
   assert_private('Service class is private, please use main class parameters.')
+
+  if $autofs::manage_service_config {
+    # Only manage the file if the path is set
+    if $autofs::service_conf_path {
+      file { 'autofs_service_config':
+        ensure  => 'file',
+        content => epp(
+          'autofs/service_conf.epp',
+          {
+            service_conf_options    => $autofs::service_conf_options,
+            service_options         => $autofs::service_options,
+            service_use_misc_device => $autofs::service_use_misc_device,
+          }
+        ),
+        group   => $autofs::map_file_group,
+        mode    => '0644',
+        notify  => Service[$autofs::service_name],
+        owner   => $autofs::map_file_owner,
+        path    => $autofs::service_conf_path,
+      }
+    }
+  }
+
+  if $autofs::manage_ldap_auth_conf {
+    # Only manage the file if the path is set
+    if $autofs::ldap_auth_conf_path {
+      file { 'autofs_ldap_auth_config':
+        ensure  => 'file',
+        content => epp(
+          'autofs/autofs_ldap_auth.conf.epp', {
+            ldap_auth_config => $autofs::ldap_auth_config,
+          }
+        ),
+        group   => $autofs::map_file_group,
+        mode    => '0600',
+        notify  => Service[$autofs::service_name],
+        owner   => $autofs::map_file_owner,
+        path    => $autofs::ldap_auth_conf_path,
+      }
+    }
+  }
+
   service { $autofs::service_name:
     ensure     => $autofs::service_ensure,
     enable     => $autofs::service_enable,

--- a/spec/unit/facter/util/fact_autofs_version_spec.rb
+++ b/spec/unit/facter/util/fact_autofs_version_spec.rb
@@ -17,7 +17,7 @@ describe Facter::Util::Fact do
     context 'autofs' do
       before do
         allow(Facter::Util::Resolution).to receive(:which).with('automount').and_return(true)
-        allow(Facter::Core::Execution).to receive(:execute).with('automount -V 2>&1').and_return('Linux automount version 5.1.1')
+        allow(Facter::Util::Resolution).to receive(:exec).with('automount -V 2>&1').and_return('Linux automount version 5.1.1')
       end
       it { expect(Facter.fact(:autofs_version).value).to eq('5.1.1') }
     end

--- a/templates/autofs_ldap_auth.conf.epp
+++ b/templates/autofs_ldap_auth.conf.epp
@@ -1,0 +1,20 @@
+<%- | Optional[Hash] $ldap_auth_config | -%>
+<?xml version="1.0" ?>
+<!--
+This files contains a single entry with multiple attributes tied to it.
+See autofs_ldap_auth.conf(5) for more information.
+###############################################################
+#                                                             #
+# THIS FILE IS MANAGED BY PUPPET. ANY CHANGES MADE TO THIS    #
+#   FILE WILL BE REVERTED BACK ON THE NEXT PUPPET RUN.        #
+#                                                             #
+###############################################################
+-->
+
+<autofs_ldap_sasl_conf
+<% if ($ldap_auth_config and $ldap_auth_config =~ Hash) { -%>
+<% $ldap_auth_config.keys.sort.each |$key| { -%>
+  <%= $key %>="<%= $ldap_auth_config[$key] %>"
+<% } -%>
+<% } -%>
+/>

--- a/templates/service_conf.epp
+++ b/templates/service_conf.epp
@@ -1,0 +1,34 @@
+<%- | Optional[Hash] $service_conf_options,
+      Optional[Array[String]] $service_options,
+      Enum['no', 'yes'] $service_use_misc_device,
+| -%>
+#
+###############################################################
+#                                                             #
+# THIS FILE IS MANAGED BY PUPPET. ANY CHANGES MADE TO THIS    #
+#   FILE WILL BE REVERTED BACK ON THE NEXT PUPPET RUN.        #
+#                                                             #
+###############################################################
+#
+# Init system options
+#
+# If the kernel supports using the autofs miscellanous device
+# and you wish to use it you must set this configuration option
+# to "yes" otherwise it will not be used.
+#
+USE_MISC_DEVICE="<%= $service_use_misc_device %>"
+#
+# Use OPTIONS to add automount(8) command line options that
+# will be used when the daemon is started.
+#
+<% if ($service_options and $service_options =~ Array) { -%>
+OPTIONS="<% $service_options.each |$opt| { %><%= $opt %> <% } -%>"
+<% } else { -%>
+#OPTIONS=""
+<% } -%>
+#
+<% if ($service_conf_options and $service_conf_options =~ Hash) { -%>
+<% $service_conf_options.keys.sort.each |$key| { -%>
+<%= $key %>=<%= $service_conf_options[$key] %>
+<% } -%>
+<% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Enable LDAP as an option when using autofs.  This requires being able to modify the following files:

* `/etc/sysconfig/autofs` (or `/etc/default/autofs` on Debian systems)
* `/etc/autofs_ldap_auth.conf`

By default, neither of these files is managed by this module to prevent backward compatibility with existing configurations.  Management of the files can be turned on individually via the `autofs::manage_service_config`
and `autofs::manage_ldap_auth_conf` booleans.  Basic spec tests were also added.