### PR TITLE
Drop OpenSuSE 13, add OpenSuSE 15.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
     {
       "operatingsystem": "OpenSuSE",
       "operatingsystemrelease": [
-        "13.1"
+        "15.2"
       ]
     },
     {


### PR DESCRIPTION
Included in https://github.com/voxpupuli/puppet-autofs/pull/162 but for a complete changelog. OpenSuSE 13 is EOL and breaking the tests.