### PR TITLE
Add support for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ autofs::mounts:
 
 The autofs module supports the use of Autofs's `+dir:` option (Autofs 5.0.5
 or later) to record master map content in drop-in files in a specified
-directory instead of directly int rhe master map.  When a `mount`'s `use_dir`
+directory instead of directly in the master map.  When a `mount`'s `use_dir`
 parameter is `true` (default is `false`), the corresponding master map entry
 is created as a separate file in the appropriate directory instead of being
 written directly into the master map.  The master map is still, however,

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,0 +1,10 @@
+---
+autofs::auto_master_map: /etc/auto_master
+autofs::map_file_group: wheel
+autofs::package_name: []
+autofs::service_name: automount
+autofs::service_ensure: ~
+autofs::automountd_service_name: automountd
+autofs::automountd_service_ensure: running
+autofs::autounmountd_service_name: autounmountd
+autofs::autounmountd_service_ensure: running

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,12 +87,16 @@
 # @param manage_ldap_auth_conf Determines if the /etc/autofs_ldap_auth.conf file should be managed
 # @param service_use_misc_device Sets the USE_MISC_DEVICE value in the service configuration file
 # @param reload_command In lieu of a service reload capability in Puppet, exec this command to reload automount without restarting it.
+# @param automountd_service_ensure Determines state of the service. Can be set to: running or stopped.
+# @param autounmountd_service_ensure Determines state of the service. Can be set to: running or stopped.
+# @param automountd_service_name Determine the name of the automountd service for cross platform compatibility
+# @param autounmountd_service_name Determine the name of the autounmountd service for cross platform compatibility
 #
 class autofs (
   String $package_ensure,
   Hash[String, Hash] $mounts,
   Variant[String, Array[String]] $package_name,
-  Enum['stopped', 'running'] $service_ensure,
+  Optional[Enum['stopped', 'running']] $service_ensure,
   Boolean $service_enable,
   String $service_name,
   String $auto_master_map,
@@ -110,6 +114,10 @@ class autofs (
   Optional[String] $reload_command = undef,
   Optional[Array[String]] $service_options = undef,
   Optional[Hash] $service_conf_options = undef,
+  Optional[Enum['stopped', 'running']] $automountd_service_ensure = undef,
+  Optional[Enum['stopped', 'running']] $autounmountd_service_ensure = undef,
+  Optional[String] $automountd_service_name = undef,
+  Optional[String] $autounmountd_service_name = undef,
 ) {
   contain 'autofs::package'
   unless $package_ensure == 'absent' {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -68,6 +68,20 @@ class autofs::service {
     require    => Class['autofs::package'],
   }
 
+  if $autofs::automountd_service_name {
+    service { $autofs::automountd_service_name:
+      ensure => $autofs::automountd_service_ensure,
+      enable => $autofs::service_enable,
+    }
+  }
+
+  if $autofs::autounmountd_service_name {
+    service { $autofs::autounmountd_service_name:
+      ensure => $autofs::autounmountd_service_ensure,
+      enable => $autofs::service_enable,
+    }
+  }
+
   if $autofs::reload_command {
     exec { 'automount-reload':
       path        => '/sbin:/usr/sbin',

--- a/metadata.json
+++ b/metadata.json
@@ -14,10 +14,10 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
+      "operatingsystem": "AIX",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7.1",
+        "7.2"
       ]
     },
     {
@@ -28,7 +28,27 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "15.2"
+      ]
+    },
+    {
       "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
         "8"
@@ -41,31 +61,10 @@
       ]
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04",
-        "18.04",
-        "20.04"
-      ]
-    },
-    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "11",
         "12"
-      ]
-    },
-    {
-      "operatingsystem": "OpenSuSE",
-      "operatingsystemrelease": [
-        "15.2"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "9",
-        "10"
       ]
     },
     {
@@ -76,10 +75,11 @@
       ]
     },
     {
-      "operatingsystem": "AIX",
+      "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "7.1",
-        "7.2"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,13 @@
       ]
     },
     {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "12",
+        "13"
+      ]
+    },
+    {
       "operatingsystem": "OpenSuSE",
       "operatingsystemrelease": [
         "15.2"

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -7,7 +7,13 @@ describe 'autofs', type: :class do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:service) { facts[:os]['family'] == 'AIX' ? 'automountd' : 'autofs' }
+      let(:service) do
+        case facts[:os]['family']
+        when 'AIX' then 'automountd'
+        when 'FreeBSD' then 'automount'
+        else 'autofs'
+        end
+      end
       let(:package) do
         case facts[:os]['family']
         when 'AIX'
@@ -30,9 +36,14 @@ describe 'autofs', type: :class do
         it { is_expected.to contain_class('autofs::service') }
 
         # Check Package and service
-        it { is_expected.to contain_package(package).with_ensure('installed') }
-        it { is_expected.to contain_service(service).that_requires("Package[#{package}]") }
-        it { is_expected.to contain_service(service).with_ensure('running') }
+        if os_facts[:os]['family'] == 'FreeBSD'
+          it { is_expected.to contain_service('automountd').with_ensure('running') }
+          it { is_expected.to contain_service('autounmountd').with_ensure('running') }
+        else
+          it { is_expected.to contain_package(package).with_ensure('installed') }
+          it { is_expected.to contain_service(service).that_requires("Package[#{package}]") }
+          it { is_expected.to contain_service(service).with_ensure('running') }
+        end
         it { is_expected.to contain_service(service).with_enable(true) }
         it { is_expected.not_to contain_file('autofs_service_config') }
         it { is_expected.not_to contain_file('autofs_ldap_auth_config') }
@@ -45,7 +56,7 @@ describe 'autofs', type: :class do
           }
         end
 
-        it { is_expected.to contain_package(package).with_ensure('absent') }
+        it { is_expected.to contain_package(package).with_ensure('absent') } if os_facts[:os]['family'] != 'FreeBSD'
       end
 
       context 'should declare mount points' do

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -5,7 +5,13 @@ describe 'autofs::map', type: :define do
     context "on #{os}" do
       let(:title) { 'data' }
       let(:pre_condition) { 'include autofs' }
-      let(:group) { facts[:os]['family'] == 'AIX' ? 'system' : 'root' }
+      let(:group) do
+        case facts[:os]['family']
+        when 'AIX' then 'system'
+        when 'FreeBSD' then 'wheel'
+        else 'root'
+        end
+      end
       let(:facts) { os_facts }
       let(:params) do
         {

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -4,8 +4,14 @@ describe 'autofs::mount', type: :define do
     context "on #{os}" do
       let(:title) { 'auto.home' }
       let(:pre_condition) { 'include autofs' }
-      let(:group) { facts[:os]['family'] == 'AIX' ? 'system' : 'root' }
-      let(:master_map_file) { %w[AIX Solaris].include?(facts[:os]['family']) ? '/etc/auto_master' : '/etc/auto.master' }
+      let(:group) do
+        case facts[:os]['family']
+        when 'AIX' then 'system'
+        when 'FreeBSD' then 'wheel'
+        else 'root'
+        end
+      end
+      let(:master_map_file) { %w[AIX FreeBSD Solaris].include?(facts[:os]['family']) ? '/etc/auto_master' : '/etc/auto.master' }
       let(:facts) { os_facts }
 
       context 'with default parameters' do


### PR DESCRIPTION
FreeBSD 10.1 added support for an autofs implementation that is similar
to what this module manage with a few minor specificities from the Linux
world:

"autofs" is the actual driver of the automounter infrastructure in the
kernel.  It communicate with the "automountd" service when a device must
be mounted, features an "autounmountd" service to unmount unused
devices, and has a rc-script "automount" to update the kernel view of
the available mountpoints.