### PR TITLE
Allow to add +auto.master in auto.master file

### DIFF
--- a/manifests/mapping.pp
+++ b/manifests/mapping.pp
@@ -100,6 +100,5 @@ define autofs::mapping (
       content => $content,
       order   => $order,
     }
-    }
   }
 }

--- a/manifests/mapping.pp
+++ b/manifests/mapping.pp
@@ -89,10 +89,18 @@ define autofs::mapping (
     }
 
     # Declare an appropriate fragment of the target map file
-    concat::fragment { "autofs::mapping/${title}":
-      target  => $mapfile,
-      content => "${key}	${formatted_options}	${fs}\n",
-      order   => $order,
+    if ($key == '+') {
+      concat::fragment { "autofs::mapping/${title}":
+        target  => $mapfile,
+        content => "${key}${fs}\n",
+        order   => $order,
+      }
+    } else {
+      concat::fragment { "autofs::mapping/${title}":
+        target  => $mapfile,
+        content => "${key}	${formatted_options}	${fs}\n",
+        order   => $order,
+      }
     }
   }
 }

--- a/manifests/mapping.pp
+++ b/manifests/mapping.pp
@@ -89,18 +89,17 @@ define autofs::mapping (
     }
 
     # Declare an appropriate fragment of the target map file
-    if ($key == '+') {
-      concat::fragment { "autofs::mapping/${title}":
-        target  => $mapfile,
-        content => "${key}${fs}\n",
-        order   => $order,
-      }
+    if $key == '+' {
+      $content = "${key}${fs}\n"
     } else {
-      concat::fragment { "autofs::mapping/${title}":
-        target  => $mapfile,
-        content => "${key}	${formatted_options}	${fs}\n",
-        order   => $order,
-      }
+      $content = "${key}	${formatted_options}	${fs}\n"
+    }
+
+    concat::fragment { "autofs::mapping/${title}":
+      target  => $mapfile,
+      content => $content,
+      order   => $order,
+    }
     }
   }
 }

--- a/spec/acceptance/autofs_init_spec.rb
+++ b/spec/acceptance/autofs_init_spec.rb
@@ -209,6 +209,41 @@ describe 'autofs' do
       end
     end
 
+    context 'master nismap inclusion test' do
+      before(:context) do
+        cleanup_helper
+      end
+
+      it 'applies' do
+        pp = <<-EOS
+          class { 'autofs':
+
+            mapfiles => {
+              '/etc/auto.master' => {
+                mappings => [
+                  { 'key' => '+', 'fs' => 'auto.master' }
+                ]
+              }
+            }
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file('/etc/auto.master') do
+        it 'exists and belongs to root' do
+          expect(subject).to exist
+          expect(subject).to be_owned_by 'root'
+          expect(subject).to be_grouped_into 'root'
+        end
+
+        its(:content) do
+          is_expected.to match %r{^\+auto.master$}
+        end
+      end
+    end
+
     context 'package set to absent' do
       before(:context) do
         cleanup_helper

--- a/spec/classes/autofs_spec.rb
+++ b/spec/classes/autofs_spec.rb
@@ -119,6 +119,30 @@ describe 'autofs', type: :class do
         end
       end
 
+      context 'should declare automaster mapfile with nismap' do
+        master_mappings = [
+          { 'key' => '+', 'fs' => 'auto.master' }
+        ]
+        let(:params) do
+          {
+            mounts: {},
+            mapfiles: {
+              'master' => { path: '/etc/auto.master', mappings: master_mappings },
+            },
+            maps: :undef
+          }
+        end
+
+        it do
+          expect(subject).to compile.with_all_deps
+          expect(subject).to contain_autofs__mapfile('master').
+            with(path: '/etc/auto.master', mappings: master_mappings)
+          expect(subject).to have_autofs__mapfile_resource_count(1)
+          expect(subject).to have_autofs__mount_resource_count(0)
+          expect(subject).to have_autofs__map_resource_count(0)
+        end
+      end
+
       context 'with $mounts not a hash' do
         let(:params) { { mounts: 'string' } }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Allows inclusion of +auto.master in /etc/auto.master by adding this to the 'mapfiles' property:
```yaml
"/etc/auto.master":
    mappings:
    - key: "+"
      fs: "auto.master"
```
#### This Pull Request (PR) fixes the following issues
