### PR TITLE
Quote and escape special chars in mapping keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -580,7 +580,7 @@ the remote filesystem to mount
 
 ##### <a name="-autofs--mapping--key"></a>`key`
 
-Data type: `Pattern[/\A\S+\z/]`
+Data type: `String[1]`
 
 the autofs key for this mapping. For indirect maps it is the
 basename of the mountpoint directory for $fs (not to be confused with
@@ -792,7 +792,7 @@ Alias of
 
 ```puppet
 Struct[{
-  key     => Pattern[/\A\S+\z/],
+  key     => String[1],
   options => Optional[Autofs::Options],
   order   => Optional[Integer],
   fs      => Pattern[/\S/]  # contains at least one non-whitespace character

--- a/manifests/mapping.pp
+++ b/manifests/mapping.pp
@@ -61,13 +61,18 @@
 #
 define autofs::mapping (
   Stdlib::Absolutepath $mapfile,
-  Pattern[/\A\S+\z/] $key,
+  String[1] $key,
   Pattern[/\S/] $fs,
   Enum['present', 'absent'] $ensure  = 'present',
   Optional[Autofs::Options] $options = undef,
   Integer $order                     = 10,
 ) {
   unless $ensure == 'absent' {
+    $formatted_key = if $key =~ /[[:blank:]"]/ {
+      String($key, '%#p')
+    } else {
+      $key
+    }
     # Format the options string, relying to some extent on the
     # $options parameter, if specified, to indeed match the
     # Autofs::Options data type
@@ -89,10 +94,10 @@ define autofs::mapping (
     }
 
     # Declare an appropriate fragment of the target map file
-    if $key == '+' {
-      $content = "${key}${fs}\n"
+    if $formatted_key == '+' {
+      $content = "${formatted_key}${fs}\n"
     } else {
-      $content = "${key}	${formatted_options}	${fs}\n"
+      $content = "${formatted_key}\t${formatted_options}\t${fs}\n"
     }
 
     concat::fragment { "autofs::mapping/${title}":

--- a/spec/defines/mapping_spec.rb
+++ b/spec/defines/mapping_spec.rb
@@ -165,6 +165,26 @@ describe 'autofs::mapping', type: :define do
             with(target: '/mnt/auto.data', content: "data	-rw	storage.host.net:/exports/data backup.host.net:/exports/data\n")
         end
       end
+
+      context 'with spaces in path' do
+        let(:params) do
+          {
+            mapfile: '/mnt/auto.data',
+            key: %(/scary/don't fear "quotes" and spaces),
+            options: 'rw',
+            fs: %("storage.host.net:/exports/data/don't fear \\"quotes\\" and spaces")
+          }
+        end
+
+        it do
+          expect(subject).to compile
+          expect(subject).not_to contain_class('autofs')
+          expect(subject).to have_concat_resource_count(0)
+          expect(subject).to have_concat__fragment_resource_count(1)
+          expect(subject).to contain_concat__fragment('autofs::mapping/data').
+            with(target: '/mnt/auto.data', content: %("/scary/don't fear \\"quotes\\" and spaces"\t-rw\t"storage.host.net:/exports/data/don't fear \\"quotes\\" and spaces"\n))
+        end
+      end
     end
   end
 end

--- a/types/fs_mapping.pp
+++ b/types/fs_mapping.pp
@@ -17,7 +17,7 @@
 #   { 'key' => 'other', 'options' => [ 'ro', 'noexec' ], 'fs' => 'external.net:/the/exported/fs' }
 #
 type Autofs::Fs_mapping = Struct[{
-  key     => Pattern[/\A\S+\z/],
+  key     => String[1],
   options => Optional[Autofs::Options],
   order   => Optional[Integer],
   fs      => Pattern[/\S/]  # contains at least one non-whitespace character


### PR DESCRIPTION
Previously, a mapping key could not include spaces because of the data
type.  Some implementations of autofs do support such keys when they are
properly quoted so do not limit their use with the module and properly
quote the key when it has special characters.

These chars still need to be manualy espaced when used with the fs
parameter because it is managed as a single String. This will be
addressed in a follow-up commit as it will be a breaking change.
