### PR TITLE
Fix extra escaping when a filesystem has spaces

### DIFF
--- a/manifests/mapping.pp
+++ b/manifests/mapping.pp
@@ -92,7 +92,7 @@ define autofs::mapping (
         default => "-${prelim_options}",
       }
     }
-    $formatted_fs = [$fs].flatten.map |$value| { if $value =~ /[[:blank:]"]/ { String($value, '%#p') } else { $value } }.join(' ')
+    $formatted_fs = [$fs].flatten.map |$value| { if $value =~ /[[:blank:]"]/ { "\"${value.regsubst(/\\/, '\\\\', 'G').regsubst(/"/, '\"', 'G')}\"" } else { $value } }.join(' ')
 
     # Declare an appropriate fragment of the target map file
     if $formatted_key == '+' {

--- a/spec/defines/mapping_spec.rb
+++ b/spec/defines/mapping_spec.rb
@@ -175,7 +175,7 @@ describe 'autofs::mapping', type: :define do
             mapfile: '/mnt/auto.data',
             key: %(/scary/don't fear "quotes" and spaces),
             options: 'rw',
-            fs: %(storage.host.net:/exports/data/don't fear "quotes" and spaces)
+            fs: %(storage.host.net:/exports/data/don't fear "quotes" and spaces nor $do\\\\ars)
           }
         end
 
@@ -185,7 +185,7 @@ describe 'autofs::mapping', type: :define do
           expect(subject).to have_concat_resource_count(0)
           expect(subject).to have_concat__fragment_resource_count(1)
           expect(subject).to contain_concat__fragment('autofs::mapping/data').
-            with(target: '/mnt/auto.data', content: %("/scary/don't fear \\"quotes\\" and spaces"\t-rw\t"storage.host.net:/exports/data/don't fear \\"quotes\\" and spaces"\n))
+            with(target: '/mnt/auto.data', content: %("/scary/don't fear \\"quotes\\" and spaces"\t-rw\t"storage.host.net:/exports/data/don't fear \\"quotes\\" and spaces nor $do\\\\ars"\n))
         end
       end
     end


### PR DESCRIPTION
When adding a filesystem with spaces, quotting is added by the module.  Unfortunately this quotting escape some chars that should be kept as-is, such as `$` or `\`.

Rework the way we quote filesystems to fix this issue.

Fix #231
